### PR TITLE
Prevent team reroll during kick off phase (catch after blitz turn)

### DIFF
--- a/FantasyFootballServer/src/com/balancedbytes/games/ffb/server/util/UtilServerReRoll.java
+++ b/FantasyFootballServer/src/com/balancedbytes/games/ffb/server/util/UtilServerReRoll.java
@@ -106,6 +106,7 @@ public class UtilServerReRoll {
       actingTeam.hasPlayer(pPlayer)
       && !game.getTurnData().isReRollUsed()
       && (game.getTurnData().getReRolls() > 0)
+      && game.getTurnMode() != TurnMode.KICKOFF
       && (game.getTurnMode() != TurnMode.PASS_BLOCK)
       && ((game.getTurnMode() != TurnMode.BOMB_HOME) || game.getTeamHome().hasPlayer(pPlayer))
       && ((game.getTurnMode() != TurnMode.BOMB_HOME_BLITZ) || game.getTeamHome().hasPlayer(pPlayer))


### PR DESCRIPTION
I chose a different approach as there are a lot of places using negation on `isHomePlaying()` which will break things when adding `null` as a third state. There is the option of setting it back but that would involve propagating the team as parameter along the steps and might still cause side effects.

Also changing the active team logic results in lots of follow up changes for serialization and stuff. So I decided to try the alternate approach which seems to work perfectly fine.

Of course the original approach would have been correct as well but the risk of getting a stuck game in some corner cases are just too big in relation to the available solution.
