### PR TITLE
This patch fixes a bug where a redirect causes fetched pages to be in…

### DIFF
--- a/ffb-client-logic/pom.xml
+++ b/ffb-client-logic/pom.xml
@@ -92,5 +92,11 @@
             <artifactId>tritonus_share</artifactId>
             <version>0.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.fumbbl.ffb</groupId>
+            <artifactId>ffb-tools</artifactId>
+            <version>2.27.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/IconCache.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/IconCache.java
@@ -15,6 +15,7 @@ import com.fumbbl.ffb.model.BlockKind;
 import com.fumbbl.ffb.model.Game;
 import com.fumbbl.ffb.model.Team;
 import com.fumbbl.ffb.option.GameOptionId;
+import com.fumbbl.ffb.tools.UtilHttpClient;
 import com.fumbbl.ffb.util.StringTool;
 import com.fumbbl.ffb.util.UtilUrl;
 
@@ -22,13 +23,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.xml.bind.DatatypeConverter;
 import java.awt.image.BufferedImage;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
@@ -267,9 +262,12 @@ public class IconCache {
 
 		} else {
 			URL iconUrl = null;
-			try {
-				iconUrl = new URL(pUrl);
-				BufferedImage icon = ImageIO.read(iconUrl);
+			ByteArrayInputStream pngByteStream;
+            try {
+                iconUrl = new URL(pUrl);
+                pngByteStream = new ByteArrayInputStream(UtilHttpClient.fetchBytes(pUrl));
+                BufferedImage icon = ImageIO.read(pngByteStream);
+				pngByteStream.close();
 				fIconByKey.put(pUrl, icon);
 				addLocalCacheEntry(iconUrl, icon);
 			} catch (Exception pAny) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/IconCache.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/IconCache.java
@@ -15,6 +15,7 @@ import com.fumbbl.ffb.model.BlockKind;
 import com.fumbbl.ffb.model.Game;
 import com.fumbbl.ffb.model.Team;
 import com.fumbbl.ffb.option.GameOptionId;
+import com.fumbbl.ffb.tools.UtilHttpClient;
 import com.fumbbl.ffb.util.StringTool;
 import com.fumbbl.ffb.util.UtilUrl;
 
@@ -22,13 +23,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.xml.bind.DatatypeConverter;
 import java.awt.image.BufferedImage;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
@@ -269,7 +264,7 @@ public class IconCache {
 			URL iconUrl = null;
 			try {
 				iconUrl = new URL(pUrl);
-				BufferedImage icon = ImageIO.read(iconUrl);
+				BufferedImage icon = ImageIO.read(new ByteArrayInputStream(UtilHttpClient.fetchBytes(pUrl)));
 				fIconByKey.put(pUrl, icon);
 				addLocalCacheEntry(iconUrl, icon);
 			} catch (Exception pAny) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/IconCache.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/IconCache.java
@@ -15,7 +15,6 @@ import com.fumbbl.ffb.model.BlockKind;
 import com.fumbbl.ffb.model.Game;
 import com.fumbbl.ffb.model.Team;
 import com.fumbbl.ffb.option.GameOptionId;
-import com.fumbbl.ffb.tools.UtilHttpClient;
 import com.fumbbl.ffb.util.StringTool;
 import com.fumbbl.ffb.util.UtilUrl;
 
@@ -23,7 +22,13 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.xml.bind.DatatypeConverter;
 import java.awt.image.BufferedImage;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
@@ -264,7 +269,7 @@ public class IconCache {
 			URL iconUrl = null;
 			try {
 				iconUrl = new URL(pUrl);
-				BufferedImage icon = ImageIO.read(new ByteArrayInputStream(UtilHttpClient.fetchBytes(pUrl)));
+				BufferedImage icon = ImageIO.read(iconUrl);
 				fIconByKey.put(pUrl, icon);
 				addLocalCacheEntry(iconUrl, icon);
 			} catch (Exception pAny) {

--- a/ffb-tools/src/main/java/com/fumbbl/ffb/tools/UtilHttpClient.java
+++ b/ffb-tools/src/main/java/com/fumbbl/ffb/tools/UtilHttpClient.java
@@ -27,16 +27,20 @@ public class UtilHttpClient {
     return result;
   }
 
-  public static String fetchPage(String pUrl) throws IOException {
+  public static byte[] fetchBytes(String pUrl) throws IOException {
     HttpClient client = new HttpClient();
     client.getHttpConnectionManager().getParams().setConnectionTimeout(CONNECTION_TIMEOUT);
     // HttpMethod method = new GetMethod(URLEncoder.encode(pUrl, CHARACTER_ENCODING));
     HttpMethod method = new GetMethod(pUrl);
     method.setFollowRedirects(true);
     client.executeMethod(method);
-    String responseBody = new String(method.getResponseBody(), CHARACTER_ENCODING);
+    byte[] responseBody = method.getResponseBody();
     method.releaseConnection();
     return responseBody;
+  }
+
+  public static String fetchPage(String pUrl) throws IOException {
+    return new String(fetchBytes(pUrl), CHARACTER_ENCODING);
   }
   
 }


### PR DESCRIPTION
…terpreted as utf8, breaking icon download.

I creates a new method fetchBytes in UtilHttpClient and makes fetchPage a special case of fetchBytes. This centralizes the http client machinery to UtilHttpClient and all calls to http servers should be made through the class rather than relying on other mechanisms.