### PR TITLE
Add support for loading new roster XML format in STANDALONE mode.

### DIFF
--- a/ffb-common/src/main/java/com/fumbbl/ffb/model/RosterSkeleton.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/model/RosterSkeleton.java
@@ -23,9 +23,10 @@ public class RosterSkeleton implements IXmlSerializable, IJsonSerializable {
 	public static final String XML_TAG = "roster";
 
 	private static final String _XML_ATTRIBUTE_ID = "id";
+	private static final String _XML_ATTRIBUTE_TEAM = "team";
 
 	private String fId;
-
+	private String fTeamId;
 
 	public String getId() {
 		return fId;
@@ -33,6 +34,14 @@ public class RosterSkeleton implements IXmlSerializable, IJsonSerializable {
 
 	public void setId(String pId) {
 		fId = pId;
+	}
+
+	public String getTeamId() {
+		return fTeamId;
+	}
+
+	public void setTeamId(String pTeamId) {
+		fTeamId = pTeamId;
 	}
 
 // XML serialization
@@ -55,6 +64,9 @@ public class RosterSkeleton implements IXmlSerializable, IJsonSerializable {
 		if (XML_TAG.equals(pXmlTag)) {
 			if (StringTool.isProvided(pXmlAttributes.getValue(_XML_ATTRIBUTE_ID))) {
 				fId = pXmlAttributes.getValue(_XML_ATTRIBUTE_ID).trim();
+			}
+			if (StringTool.isProvided(pXmlAttributes.getValue(_XML_ATTRIBUTE_TEAM))) {
+				fTeamId = pXmlAttributes.getValue(_XML_ATTRIBUTE_TEAM).trim();
 			}
 		}
 		return this;

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/GameCache.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/GameCache.java
@@ -243,7 +243,7 @@ public class GameCache {
 
 	private Team updateRoster(Team team, Game game) {
 		if (ServerMode.STANDALONE == getServer().getMode()) {
-			team.updateRoster(rosterCache.getRosterById(team.getRosterId(), game), game.getRules());
+			team.updateRoster(rosterCache.getRosterForTeam(team, game), game.getRules());
 			team.setTeamValue(UtilTeamValue.findTeamValue(team));
 		}
 		return team;

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/RosterCache.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/RosterCache.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fumbbl.ffb.model.Team;
 import org.xml.sax.InputSource;
 
 import com.fumbbl.ffb.FantasyFootballException;
@@ -17,26 +18,53 @@ import com.fumbbl.ffb.util.FileIterator;
 import com.fumbbl.ffb.xml.XmlHandler;
 
 /**
+ * Roster Cache used when the server is in STANDALONE mode.
+ *
+ * For the cache to work, two files have to exist:
+ *
+ * 1. A team xml in `/ffb-server/teams`.
+ * 2. A roster xml in `/ffb-server/roster`
+ *
+ * The format of these has evolved over time and is not fixed. E.g., in older formats, the `<rosterId>` in the
+ * team XML is used to find the matching roster, while in newer formats, the team id is used directly.
+ *
+ * The easiest way to add new teams to the cache is by copying the output from the FUMBBL live server. This is done
+ * by copying the result of these two API calls (replace team id with the wanted team):
+ *
+ * 1. Team information: https://fumbbl.com/xml:team?id=284314
+ * 2. Roster information: https://fumbbl.com/xml:roster?team=284314
  *
  * @author Kalimar
  */
 public class RosterCache {
 
-	private Map<String, File> rosterFileById;
+	private Map<String, File> rosterFileByRosterId;
+	private Map<String, File> rosterFileByTeamId;
 
 	public RosterCache() {
-		rosterFileById = new HashMap<>();
+		rosterFileByRosterId = new HashMap<>();
+		rosterFileByTeamId = new HashMap<>();
 	}
 
-	public Roster getRosterById(String rosterId, Game game) {
-		try (BufferedReader xmlIn = new BufferedReader(new FileReader(rosterFileById.get(rosterId)))) {
+	public Roster getRosterForTeam(Team team, Game game) {
+		// In newer versions of the XML format, the `<rosterId>` is not used (but is still present).
+		// So we first check for the presence of a roster matching the team id, and only if no roster
+		// is found, do we fall back to looking up the roster using the original rosterId.
+		File rosterFile = rosterFileByTeamId.get(team.getId());
+		if (rosterFile == null) {
+			rosterFile = rosterFileByRosterId.get(team.getRosterId());
+		}
+		if (rosterFile == null) {
+			throw new IllegalStateException("No roster found for neither rosterId (" + team.getRosterId() + ") nor teamId (" + team.getId() + ")");
+		}
+		try (BufferedReader xmlIn = new BufferedReader(new FileReader(rosterFile))) {
 			InputSource xmlSource = new InputSource(xmlIn);
 			Roster roster = new Roster();
 			XmlHandler.parse(game, xmlSource, roster);
 
 			return roster;
 		} catch (FantasyFootballException | IOException pFfe) {
-			throw new FantasyFootballException("Error deserializing roster for id " + rosterId, pFfe);
+			throw new FantasyFootballException("Error deserializing roster file: " + rosterFile.getAbsolutePath(), pFfe);
 		}
 	}
 
@@ -50,7 +78,13 @@ public class RosterCache {
 				RosterSkeleton roster = new RosterSkeleton();
 				XmlHandler.parse(null, xmlSource, roster);
 
-				rosterFileById.put(roster.getId(), file);
+				if (roster.getTeamId() != null) {
+					rosterFileByTeamId.put(roster.getTeamId(), file);
+				} else if (roster.getId() != null) {
+					rosterFileByRosterId.put(roster.getId(), file);
+				} else {
+					throw new IllegalStateException("Roster are missing either an 'id' or 'team' attribute.");
+				}
 			} catch (FantasyFootballException pFfe) {
 				throw new FantasyFootballException("Error populating roster cache for file" + file.getAbsolutePath(), pFfe);
 			}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/handler/ServerCommandHandlerJoinApproved.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/handler/ServerCommandHandlerJoinApproved.java
@@ -251,6 +251,9 @@ public class ServerCommandHandlerJoinApproved extends ServerCommandHandler {
 					.add(new FumbblRequestLoadTeamList(pGameState, pJoinApprovedCommand.getCoach(), pSession));
 		} else {
 			TeamList teamList = new TeamList();
+			// In STANDALONE mode, we need to initialize the rules before we start parsing teams.
+			pGameState.initRulesDependentMembers();
+			pGameState.getGame().initializeRules();
 			Team[] teams = getServer().getGameCache().getTeamsForCoach(pJoinApprovedCommand.getCoach(), pGameState.getGame());
 			for (Team team : teams) {
 				TeamListEntry teamEntry = new TeamListEntry();


### PR DESCRIPTION
Closes #76 

This patch makes it possible to copy the XML output of the FUMBBL API and use it for testing while the server is running in STANDALONE mode.

An example is here where a pre-existing team is playing against a team copied from FUMBBL:

![image](https://github.com/user-attachments/assets/ce875ede-9974-4494-8c89-b9039635a2ce)
