### PR TITLE
Fix local standalone setup for amazons.

### DIFF
--- a/ffb-server/setups/setup_amazon_Kalimar.xml
+++ b/ffb-server/setups/setup_amazon_Kalimar.xml
@@ -3,47 +3,47 @@
 <teamSetup teamId="teamAmazonKalimar" name="Amazon Team Setup">
 
   <player nr="1">
-    <coordinate x="13" y="4" />
+    <coordinate x="11" y="4" />
   </player>
 
   <player nr="2">
-    <coordinate x="13" y="12" />
+    <coordinate x="11" y="12" />
   </player>
 
   <player nr="3">
-    <coordinate x="13" y="10" />
+    <coordinate x="11" y="10" />
   </player>
 
   <player nr="4">
-    <coordinate x="13" y="2" />
+    <coordinate x="11" y="2" />
   </player>
 
   <player nr="5">
-    <coordinate x="5" y="4" />
+    <coordinate x="3" y="4" />
   </player>
 
   <player nr="6">
-    <coordinate x="5" y="10" />
+    <coordinate x="3" y="10" />
   </player>
 
   <player nr="7">
-    <coordinate x="12" y="1" />
+    <coordinate x="10" y="1" />
   </player>
 
   <player nr="8">
-    <coordinate x="12" y="13" />
+    <coordinate x="10" y="13" />
   </player>
 
   <player nr="9">
-    <coordinate x="14" y="7" />
+    <coordinate x="12" y="7" />
   </player>
 
   <player nr="10">
-    <coordinate x="14" y="6" />
+    <coordinate x="12" y="6" />
   </player>
 
   <player nr="11">
-    <coordinate x="14" y="8" />
+    <coordinate x="12" y="8" />
   </player>
 
 </teamSetup>


### PR DESCRIPTION
Before this fix, the local Amazon setup placed players two squares too much to the right, placing them on the opponent's half. The client didn't allow you to start the game though, so this is just a minor fix when doing local testing.

Before this fix, it looked like this:
![image](https://github.com/user-attachments/assets/a9785b76-cada-448c-8f4f-33c4ca97462c)
