### PR TITLE
Woodland Fury (Star Willow Rosebark)

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogBlockRollPartialReRollHandler.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogBlockRollPartialReRollHandler.java
@@ -89,7 +89,8 @@ public class DialogBlockRollPartialReRollHandler extends DialogHandler {
 						communication.sendUseConsummateReRollForBlock(blockRollDialog.getReRollIndexes().get(0));
 					} else if (blockRollDialog.getReRollSource() != null &&
 						blockRollDialog.getReRollSource() == blockRollDialog.getSingleBlockDieReRollSource()) {
-						communication.sendUseSingleBlockDieReRollForBlock(blockRollDialog.getReRollIndexes().get(0));
+						communication.sendUseSingleBlockDieReRollForBlock(blockRollDialog.getReRollIndexes().get(0),
+							blockRollDialog.getSingleBlockDieReRollSource());
 					} else if (blockRollDialog.getReRollSource() != null &&
 						blockRollDialog.getReRollSource() == blockRollDialog.getAnyBlockDiceReRollSource()) {
 						communication.sendUseMultiBlockDiceReRoll(

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogBlockRollPropertiesHandler.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogBlockRollPropertiesHandler.java
@@ -103,7 +103,8 @@ public class DialogBlockRollPropertiesHandler extends DialogHandler {
 					} else if (blockRollDialog.getReRollSource() != null && blockRollDialog.getReRollSource() == blockRollDialog.getSingleDieReRollSource()) {
 						communication.sendUseConsummateReRollForBlock(blockRollDialog.getReRollIndexes().get(0));
 					} else if (blockRollDialog.getReRollSource() != null && blockRollDialog.getReRollSource() == blockRollDialog.getSingleBlockDieReRollSource()) {
-						communication.sendUseSingleBlockDieReRollForBlock(blockRollDialog.getReRollIndexes().get(0));
+						communication.sendUseSingleBlockDieReRollForBlock(blockRollDialog.getReRollIndexes().get(0),
+							blockRollDialog.getSingleBlockDieReRollSource());
 					} else if (blockRollDialog.getReRollSource() != null && blockRollDialog.getReRollSource() == blockRollDialog.getAnyBlockDiceReRollSource()) {
 						communication.sendUseMultiBlockDiceReRoll(blockRollDialog.getReRollIndexes().stream().mapToInt(i -> i).toArray());
 					} else {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -22,6 +22,7 @@ public class ChangeList {
 			.addFeature("Biased ref: Coach is banned on a natural 1 even with biased ref")
 			.addFeature("Throw-Ins: The first square (under template) counts and corner Throw-Ins")
 			.addBugfix("Tentacles only works on dodge and jump/leap")
+			.addBugfix("Woodland Fury (Star Willow Rosebark")
 		);
 
 		versions.add(new VersionChangeList("2026-02-01")

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/net/ClientCommunication.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/net/ClientCommunication.java
@@ -255,8 +255,8 @@ public class ClientCommunication implements Runnable, INetCommandHandler {
 		send(new ClientCommandUseConsummateReRollForBlock(proIndex));
 	}
 
-	public void sendUseSingleBlockDieReRollForBlock(int index) {
-		send(new ClientCommandUseSingleBlockDieReRoll(index));
+	public void sendUseSingleBlockDieReRollForBlock(int index, ReRollSource source) {
+		send(new ClientCommandUseSingleBlockDieReRoll(index, source));
 	}
 
 	public void sendUseMultiBlockDiceReRoll(int[] indexes) {

--- a/ffb-common/src/main/java/com/fumbbl/ffb/ReRollSources.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/ReRollSources.java
@@ -41,6 +41,7 @@ public class ReRollSources {
 	public static final ReRollSource SWOOP = new ReRollSource("Swoop");
 	public static final ReRollSource HATRED = new ReRollSource("Hatred");
 	public static final ReRollSource WORKING_IN_TANDEM = new ReRollSource("Working in Tandem");
+	public static final ReRollSource WOODLAND_FURY = new ReRollSource("Woodland Fury");
 
 	private final Map<String, ReRollSource> values;
 

--- a/ffb-common/src/main/java/com/fumbbl/ffb/model/property/NamedProperties.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/model/property/NamedProperties.java
@@ -126,6 +126,7 @@ public class NamedProperties {
 	public static final ISkillProperty canRerollSingleBlockDieOncePerPeriod = new NamedProperty("Can Reroll Single Block Die Once Per Period");
 	public static final ISkillProperty canRerollSingleBlockDieDuringBlitz = new NamedProperty("Can Reroll Single Block Die During Blitz");
 	public static final ISkillProperty canRerollSingleBlockDieWhenPartnerIsMarking = new NamedProperty("Can Reroll Single Block Die When Partner Is Marking");
+	public static final ISkillProperty canRerollSingleBlockDieWhenWouldBeKnockedDown = new NamedProperty("Can Reroll Single Block Die When Would Be Knocked Down");
 	public static final ISkillProperty canRerollSingleSkull = new NamedProperty("Can Reroll Single Skull");
 	public static final ISkillProperty canRollToMatchOpponentsStrength = new NamedProperty(
 		"Can Roll To Match Opponents Strength");

--- a/ffb-common/src/main/java/com/fumbbl/ffb/model/property/NamedProperties.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/model/property/NamedProperties.java
@@ -53,6 +53,7 @@ public class NamedProperties {
 	public static final ISkillProperty canChooseToIgnoreRushModifierAfterRoll = new NamedProperty("Can Choose To Ignore Rush Modifier After Roll");
 	public static final ISkillProperty canChooseOwnPushedBackSquare = new NamedProperty(
 		"Can Choose Own Pushed Back Square");
+	public static final ISkillProperty canConvertBothDownToPush = new NamedProperty("Can Convert BothDown To Push");
 	public static final ISkillProperty canDoubleStrengthAfterDauntless = new NamedProperty("Can Double Strength After Dauntless");
 	public static final ISkillProperty canDropBall = new NamedProperty("Can Drop Ball");
 	public static final ISkillProperty canFollowPlayerLeavingTacklezones = new NamedProperty("Can Follow Player Leaving Tacklezones");

--- a/ffb-common/src/main/java/com/fumbbl/ffb/net/commands/ClientCommandUseSingleBlockDieReRoll.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/net/commands/ClientCommandUseSingleBlockDieReRoll.java
@@ -2,6 +2,8 @@ package com.fumbbl.ffb.net.commands;
 
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
+
+import com.fumbbl.ffb.ReRollSource;
 import com.fumbbl.ffb.factory.IFactorySource;
 import com.fumbbl.ffb.json.IJsonOption;
 import com.fumbbl.ffb.json.UtilJson;
@@ -13,6 +15,7 @@ import com.fumbbl.ffb.net.NetCommandId;
 public class ClientCommandUseSingleBlockDieReRoll extends ClientCommand {
 
 	private int dieIndex;
+	private ReRollSource reRollSource;
 
 	public ClientCommandUseSingleBlockDieReRoll() {
 		super();
@@ -20,6 +23,11 @@ public class ClientCommandUseSingleBlockDieReRoll extends ClientCommand {
 
 	public ClientCommandUseSingleBlockDieReRoll(int dieIndex) {
 		this.dieIndex = dieIndex;
+	}
+
+	public ClientCommandUseSingleBlockDieReRoll(int dieIndex, ReRollSource reRollSource) {
+		this.dieIndex = dieIndex;
+		this.reRollSource = reRollSource;
 	}
 
 	public NetCommandId getId() {
@@ -30,9 +38,14 @@ public class ClientCommandUseSingleBlockDieReRoll extends ClientCommand {
 		return dieIndex;
 	}
 
+	public ReRollSource getReRollSource() {
+		return reRollSource;
+	}
+
 	public JsonObject toJsonValue() {
 		JsonObject jsonObject = super.toJsonValue();
 		IJsonOption.BLOCK_DIE_INDEX.addTo(jsonObject, dieIndex);
+		IJsonOption.RE_ROLL_SOURCE.addTo(jsonObject, reRollSource);
 		return jsonObject;
 	}
 
@@ -40,6 +53,7 @@ public class ClientCommandUseSingleBlockDieReRoll extends ClientCommand {
 		super.initFrom(source, jsonValue);
 		JsonObject jsonObject = UtilJson.toJsonObject(jsonValue);
 		dieIndex = IJsonOption.BLOCK_DIE_INDEX.getFrom(source, jsonObject);
+		reRollSource = (ReRollSource) IJsonOption.RE_ROLL_SOURCE.getFrom(source, jsonObject);
 		return this;
 	}
 

--- a/ffb-common/src/main/java/com/fumbbl/ffb/skill/bb2025/Juggernaut.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/skill/bb2025/Juggernaut.java
@@ -1,0 +1,36 @@
+package com.fumbbl.ffb.skill.bb2025;
+
+import com.fumbbl.ffb.RulesCollection;
+import com.fumbbl.ffb.SkillCategory;
+import com.fumbbl.ffb.RulesCollection.Rules;
+import com.fumbbl.ffb.model.property.CancelSkillProperty;
+import com.fumbbl.ffb.model.property.NamedProperties;
+import com.fumbbl.ffb.model.skill.Skill;
+
+/**
+ * A player with this skill is virtually impossible to stop once he is in
+ * motion. If this player takes a Blitz Action, then opposing players may not
+ * use their Fend, Stand Firm or Wrestle skills against blocks, and he may
+ * choose to treat a "Both Down" result as if a "Pushed" result has been rolled
+ * instead.
+ */
+@RulesCollection(Rules.BB2025)
+public class Juggernaut extends Skill {
+
+	public Juggernaut() {
+		super("Juggernaut", SkillCategory.STRENGTH);
+	}
+
+	@Override
+	public void postConstruct() {
+		registerProperty(new CancelSkillProperty(NamedProperties.canTakeDownPlayersWithHimOnBothDown));
+		registerProperty(new CancelSkillProperty(NamedProperties.canRefuseToBePushed));
+		registerProperty(new CancelSkillProperty(NamedProperties.preventOpponentFollowingUp));
+		registerProperty(NamedProperties.canConvertBothDownToPush);
+	}
+
+	@Override
+	public String[] getSkillUseDescription() {
+		return new String[] { "Using Juggernaut will convert the BOTH DOWN Block Result into a PUSHBACK." };
+	}
+}

--- a/ffb-common/src/main/java/com/fumbbl/ffb/skill/bb2025/special/WoodlandFury.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/skill/bb2025/special/WoodlandFury.java
@@ -1,0 +1,28 @@
+package com.fumbbl.ffb.skill.bb2025.special;
+
+import com.fumbbl.ffb.ReRollSources;
+import com.fumbbl.ffb.ReRolledActions;
+import com.fumbbl.ffb.RulesCollection;
+import com.fumbbl.ffb.RulesCollection.Rules;
+import com.fumbbl.ffb.SkillCategory;
+import com.fumbbl.ffb.model.property.NamedProperties;
+import com.fumbbl.ffb.model.skill.Skill;
+import com.fumbbl.ffb.model.skill.SkillUsageType;
+
+/**
+ * Once per game, when Willow performs a Block Action that would result in her being Knocked Down,
+ * she can choose to re-roll a single Block Dice.
+ */
+
+@RulesCollection(Rules.BB2025)
+public class WoodlandFury extends Skill {
+	public WoodlandFury() {
+		super("Woodland Fury", SkillCategory.TRAIT, SkillUsageType.ONCE_PER_GAME);
+	}
+
+	@Override
+	public void postConstruct() {
+		registerProperty(NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown);
+		registerRerollSource(ReRolledActions.SINGLE_BLOCK_DIE, ReRollSources.WOODLAND_FURY);
+	}
+}

--- a/ffb-common/src/main/java/com/fumbbl/ffb/skill/mixed/Juggernaut.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/skill/mixed/Juggernaut.java
@@ -1,4 +1,4 @@
-package com.fumbbl.ffb.skill.common;
+package com.fumbbl.ffb.skill.mixed;
 
 import com.fumbbl.ffb.RulesCollection;
 import com.fumbbl.ffb.SkillCategory;
@@ -14,7 +14,8 @@ import com.fumbbl.ffb.model.skill.Skill;
  * choose to treat a "Both Down" result as if a "Pushed" result has been rolled
  * instead.
  */
-@RulesCollection(Rules.COMMON)
+@RulesCollection(Rules.BB2016)
+@RulesCollection(Rules.BB2020)
 public class Juggernaut extends Skill {
 
 	public Juggernaut() {

--- a/ffb-common/src/main/java/com/fumbbl/ffb/util/UtilPlayer.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/util/UtilPlayer.java
@@ -689,7 +689,7 @@ public class UtilPlayer {
 		boolean bothDownSafe = actingPlayer.getPlayer().hasSkillProperty(NamedProperties.preventFallOnBothDown)
 			|| actingPlayer.getPlayer().hasSkillProperty(NamedProperties.canTakeDownPlayersWithHimOnBothDown)
 			|| (actingPlayer.getPlayerAction().isBlitzing()
-				&& UtilCards.hasSkillToCancelProperty(actingPlayer.getPlayer(), NamedProperties.canTakeDownPlayersWithHimOnBothDown));
+				&& actingPlayer.getPlayer().hasSkillProperty(NamedProperties.canConvertBothDownToPush));
 
 		boolean anyKnockDown = false;
 		boolean allKnockDown = true;

--- a/ffb-common/src/main/java/com/fumbbl/ffb/util/UtilPlayer.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/util/UtilPlayer.java
@@ -684,7 +684,6 @@ public class UtilPlayer {
 		return ArrayTool.isProvided(players) && players.length > 1;
 	}
 
-
 	public static boolean blockWouldKnockDownAttacker(Game game, ActingPlayer actingPlayer, int[] blockRoll, boolean defenderChooses) {
 		BlockResultFactory factory = game.getFactory(FactoryType.Factory.BLOCK_RESULT);
 		boolean bothDownSafe = actingPlayer.getPlayer().hasSkillProperty(NamedProperties.preventFallOnBothDown)
@@ -692,20 +691,18 @@ public class UtilPlayer {
 			|| (actingPlayer.getPlayerAction().isBlitzing()
 				&& UtilCards.hasSkillToCancelProperty(actingPlayer.getPlayer(), NamedProperties.canTakeDownPlayersWithHimOnBothDown));
 
+		boolean anyKnockDown = false;
+		boolean allKnockDown = true;
 		for (int roll : blockRoll) {
 			BlockResult result = factory.forRoll(roll);
-			boolean knocksDown = (result == BlockResult.SKULL) || (result == BlockResult.BOTH_DOWN && !bothDownSafe);
-			if (defenderChooses) {
-				if (knocksDown) {
-					return true; // any bad face on uphill
-				}
+			boolean knocksDown = result == BlockResult.SKULL || (result == BlockResult.BOTH_DOWN && !bothDownSafe);
+			if (knocksDown) {
+				anyKnockDown = true;
 			} else {
-				if (!knocksDown) {
-					return false; // need all bad faces on normal
-				}
+				allKnockDown = false;
 			}
 		}
-		return !defenderChooses; // true if all were bad on normal; false if no bad on uphill
+		return defenderChooses ? anyKnockDown : allKnockDown;
 	}
 
 

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/JuggernautBehaviour.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/JuggernautBehaviour.java
@@ -1,4 +1,4 @@
-package com.fumbbl.ffb.server.skillbehaviour.common;
+package com.fumbbl.ffb.server.skillbehaviour.bb2025;
 
 import com.fumbbl.ffb.BlockResult;
 import com.fumbbl.ffb.PlayerAction;
@@ -20,10 +20,10 @@ import com.fumbbl.ffb.server.step.action.block.StepJuggernaut;
 import com.fumbbl.ffb.server.step.action.block.StepJuggernaut.StepState;
 import com.fumbbl.ffb.server.step.action.block.UtilBlockSequence;
 import com.fumbbl.ffb.server.util.UtilServerDialog;
-import com.fumbbl.ffb.skill.common.Juggernaut;
+import com.fumbbl.ffb.skill.bb2025.Juggernaut;
 import com.fumbbl.ffb.util.UtilCards;
 
-@RulesCollection(Rules.COMMON)
+@RulesCollection(Rules.BB2025)
 public class JuggernautBehaviour extends SkillBehaviour<Juggernaut> {
 	public JuggernautBehaviour() {
 		super();

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/mixed/JuggernautBehaviour.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/mixed/JuggernautBehaviour.java
@@ -1,0 +1,71 @@
+package com.fumbbl.ffb.server.skillbehaviour.mixed;
+
+import com.fumbbl.ffb.BlockResult;
+import com.fumbbl.ffb.PlayerAction;
+import com.fumbbl.ffb.RulesCollection;
+import com.fumbbl.ffb.RulesCollection.Rules;
+import com.fumbbl.ffb.SkillUse;
+import com.fumbbl.ffb.dialog.DialogSkillUseParameter;
+import com.fumbbl.ffb.model.ActingPlayer;
+import com.fumbbl.ffb.model.Game;
+import com.fumbbl.ffb.net.commands.ClientCommandUseSkill;
+import com.fumbbl.ffb.report.ReportSkillUse;
+import com.fumbbl.ffb.server.model.SkillBehaviour;
+import com.fumbbl.ffb.server.model.StepModifier;
+import com.fumbbl.ffb.server.step.StepAction;
+import com.fumbbl.ffb.server.step.StepCommandStatus;
+import com.fumbbl.ffb.server.step.StepParameter;
+import com.fumbbl.ffb.server.step.StepParameterKey;
+import com.fumbbl.ffb.server.step.action.block.StepJuggernaut;
+import com.fumbbl.ffb.server.step.action.block.StepJuggernaut.StepState;
+import com.fumbbl.ffb.server.step.action.block.UtilBlockSequence;
+import com.fumbbl.ffb.server.util.UtilServerDialog;
+import com.fumbbl.ffb.skill.mixed.Juggernaut;
+import com.fumbbl.ffb.util.UtilCards;
+
+@RulesCollection(Rules.BB2016)
+@RulesCollection(Rules.BB2020)
+public class JuggernautBehaviour extends SkillBehaviour<Juggernaut> {
+	public JuggernautBehaviour() {
+		super();
+
+		registerModifier(new StepModifier<StepJuggernaut, StepJuggernaut.StepState>() {
+
+			@Override
+			public StepCommandStatus handleCommandHook(StepJuggernaut step, StepState state,
+					ClientCommandUseSkill useSkillCommand) {
+				state.usingJuggernaut = useSkillCommand.isSkillUsed();
+				return StepCommandStatus.EXECUTE_STEP;
+			}
+
+			@Override
+			public boolean handleExecuteStepHook(StepJuggernaut step, StepState state) {
+				Game game = step.getGameState().getGame();
+				ActingPlayer actingPlayer = game.getActingPlayer();
+				UtilServerDialog.hideDialog(step.getGameState());
+				if ((PlayerAction.BLITZ == actingPlayer.getPlayerAction()) && UtilCards.hasSkill(actingPlayer, skill)) {
+					if (state.usingJuggernaut == null) {
+						UtilServerDialog.showDialog(step.getGameState(),
+							new DialogSkillUseParameter(actingPlayer.getPlayer().getId(), skill, 0), false);
+					} else {
+						if (state.usingJuggernaut) {
+							step.getResult()
+								.addReport(new ReportSkillUse(actingPlayer.getPlayerId(), skill, true, SkillUse.PUSH_BACK_OPPONENT));
+							step.publishParameter(new StepParameter(StepParameterKey.BLOCK_RESULT, BlockResult.PUSHBACK));
+							game.getFieldModel().setPlayerState(game.getDefender(), state.oldDefenderState);
+							step.publishParameters(UtilBlockSequence.initPushback(step));
+							step.getResult().setNextAction(StepAction.GOTO_LABEL, state.goToLabelOnSuccess);
+						} else {
+							step.getResult().addReport(new ReportSkillUse(actingPlayer.getPlayerId(), skill, false, null));
+							step.getResult().setNextAction(StepAction.NEXT_STEP);
+						}
+					}
+				} else {
+					step.getResult().setNextAction(StepAction.NEXT_STEP);
+				}
+				return false;
+			}
+
+		});
+	}
+}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepBlockRoll.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepBlockRoll.java
@@ -134,31 +134,11 @@ public class StepBlockRoll extends AbstractStepWithReRoll {
 					commandStatus = StepCommandStatus.EXECUTE_STEP;
 					break;
 				case CLIENT_USE_SINGLE_BLOCK_DIE_RE_ROLL:
-					ClientCommandUseSingleBlockDieReRoll commandUseSkill =
-						(ClientCommandUseSingleBlockDieReRoll) pReceivedCommand.getCommand();
-					Skill rerollSkill = null;
-					if (UtilPlayer.blockWouldKnockDownAttacker(getGameState().getGame(), actingPlayer, fBlockRoll, fNrOfDice < 0)) {
-						rerollSkill = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown);
-					}
-					if (rerollSkill == null && UtilPlayer.isAttackerWorkingInTandem(getGameState().getGame(), actingPlayer.getPlayer(), 
-						getGameState().getGame().getDefender())) {
-						rerollSkill = 
-							UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenPartnerIsMarking);
-					}
-					if (rerollSkill == null && actingPlayer.getPlayerAction().isBlitzing()) {
-						rerollSkill = 
-							UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieDuringBlitz);
-					}
-					if (rerollSkill == null) {
-						rerollSkill =
-							UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieOncePerPeriod);
-					}
-					if (rerollSkill != null) {
-						setReRolledAction(ReRolledActions.BLOCK);
-						setReRollSource(rerollSkill.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE));
-						dieIndex = commandUseSkill.getDieIndex();
-						commandStatus = StepCommandStatus.EXECUTE_STEP;
-					}
+					ClientCommandUseSingleBlockDieReRoll commandUseSkill = (ClientCommandUseSingleBlockDieReRoll) pReceivedCommand.getCommand();
+					setReRolledAction(ReRolledActions.BLOCK);
+					setReRollSource(commandUseSkill.getReRollSource());
+					dieIndex = commandUseSkill.getDieIndex();
+					commandStatus = StepCommandStatus.EXECUTE_STEP;
 					break;
 				case CLIENT_USE_MULTI_BLOCK_DICE_RE_ROLL:
 					ClientCommandUseMultiBlockDiceReRoll commandMultiRrr =
@@ -321,7 +301,11 @@ public class StepBlockRoll extends AbstractStepWithReRoll {
 		if (getReRollSource() == null) {
 
 			ReRollSource singleBlock = null;
-			if (actingPlayer.getPlayerAction().isBlitzing()
+			if (UtilPlayer.blockWouldKnockDownAttacker(game, actingPlayer, fBlockRoll, fNrOfDice < 0)
+				&& UtilCards.hasUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown)) {
+				singleBlock = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown)
+					.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE);
+			} else if (actingPlayer.getPlayerAction().isBlitzing()
 				&& UtilCards.hasUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieDuringBlitz)) {
 				singleBlock = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieDuringBlitz)
 					.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE);
@@ -330,10 +314,6 @@ public class StepBlockRoll extends AbstractStepWithReRoll {
 					.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE);
 			} else if (UtilPlayer.isAttackerWorkingInTandem(game, actingPlayer.getPlayer(), game.getDefender())) {
 				singleBlock = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenPartnerIsMarking)
-					.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE);
-			} else if (UtilPlayer.blockWouldKnockDownAttacker(game, actingPlayer, fBlockRoll, fNrOfDice < 0)
-				&& UtilCards.hasUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown)) {
-				singleBlock = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown)
 					.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE);
 			}
 			if (singleBlock != null) {

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepBlockRoll.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepBlockRoll.java
@@ -137,7 +137,10 @@ public class StepBlockRoll extends AbstractStepWithReRoll {
 					ClientCommandUseSingleBlockDieReRoll commandUseSkill =
 						(ClientCommandUseSingleBlockDieReRoll) pReceivedCommand.getCommand();
 					Skill rerollSkill = null;
-					if (UtilPlayer.isAttackerWorkingInTandem(getGameState().getGame(), actingPlayer.getPlayer(), 
+					if (UtilPlayer.blockWouldKnockDownAttacker(getGameState().getGame(), actingPlayer, fBlockRoll, fNrOfDice < 0)) {
+						rerollSkill = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown);
+					}
+					if (rerollSkill == null && UtilPlayer.isAttackerWorkingInTandem(getGameState().getGame(), actingPlayer.getPlayer(), 
 						getGameState().getGame().getDefender())) {
 						rerollSkill = 
 							UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenPartnerIsMarking);
@@ -267,7 +270,8 @@ public class StepBlockRoll extends AbstractStepWithReRoll {
 			fBlockRoll[dieIndex] = reRolledWithPro[0];
 		} else if (getReRollSource() == ReRollSources.UNSTOPPABLE_MOMENTUM
 			|| getReRollSource() == ReRollSources.LORD_OF_CHAOS
-			|| getReRollSource() == ReRollSources.WORKING_IN_TANDEM) {
+			|| getReRollSource() == ReRollSources.WORKING_IN_TANDEM
+			|| getReRollSource() == ReRollSources.WOODLAND_FURY) {
 			if (dieIndex >= 0) {
 				int rerolledDie = getGameState().getDiceRoller().rollBlockDice(1)[0];
 				getResult().addReport(
@@ -316,13 +320,24 @@ public class StepBlockRoll extends AbstractStepWithReRoll {
 
 		if (getReRollSource() == null) {
 
-			if (actingPlayer.getPlayerAction().isBlitzing()) {
-				addReRollSourceMapping(actionToSource, ReRolledActions.SINGLE_BLOCK_DIE, game); // Borak + UM on blitz
-			} else if (UtilCards.hasUnusedSkillWithProperty(actingPlayer,
-				NamedProperties.canRerollSingleBlockDieOncePerPeriod)) {
-				addReRollSourceMapping(actionToSource, ReRolledActions.SINGLE_BLOCK_DIE, game); // Borak on Block
+			ReRollSource singleBlock = null;
+			if (actingPlayer.getPlayerAction().isBlitzing()
+				&& UtilCards.hasUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieDuringBlitz)) {
+				singleBlock = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieDuringBlitz)
+					.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE);
+			} else if (UtilCards.hasUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieOncePerPeriod)) {
+				singleBlock = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieOncePerPeriod)
+					.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE);
 			} else if (UtilPlayer.isAttackerWorkingInTandem(game, actingPlayer.getPlayer(), game.getDefender())) {
-				addReRollSourceMapping(actionToSource, ReRolledActions.SINGLE_BLOCK_DIE, game); // Lucien with Valen marking
+				singleBlock = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenPartnerIsMarking)
+					.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE);
+			} else if (UtilPlayer.blockWouldKnockDownAttacker(game, actingPlayer, fBlockRoll, fNrOfDice < 0)
+				&& UtilCards.hasUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown)) {
+				singleBlock = UtilCards.getUnusedSkillWithProperty(actingPlayer, NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown)
+					.getRerollSource(ReRolledActions.SINGLE_BLOCK_DIE);
+			}
+			if (singleBlock != null) {
+				actionToSource.put(ReRolledActions.SINGLE_BLOCK_DIE, singleBlock);
 			}
 
 			addReRollSourceMapping(actionToSource, ReRolledActions.SINGLE_DIE, game);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/mutliblock/StepBlockRollMultiple.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/mutliblock/StepBlockRollMultiple.java
@@ -344,7 +344,9 @@ public class StepBlockRollMultiple extends AbstractStepMultiple {
 		addReRollSourceMapping(actionReRollSourceMap, ReRolledActions.SINGLE_DIE, game);
 		addReRollSourceMapping(actionReRollSourceMap, ReRolledActions.MULTI_BLOCK_DICE, game);
 		if (UtilCards.hasUnusedSkillWithProperty(game.getActingPlayer(), NamedProperties.canRerollSingleBlockDieOncePerPeriod)
-			|| (UtilPlayer.isAttackerWorkingInTandem(game, game.getActingPlayer().getPlayer(), game.getPlayerById(roll.getTargetId())))) {
+			|| (UtilPlayer.isAttackerWorkingInTandem(game, game.getActingPlayer().getPlayer(), game.getPlayerById(roll.getTargetId())))
+			|| (UtilCards.hasUnusedSkillWithProperty(game.getActingPlayer(), NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown)
+				&& UtilPlayer.blockWouldKnockDownAttacker(game, game.getActingPlayer(), roll.getBlockRoll(), !roll.isOwnChoice()))) {
 			addReRollSourceMapping(actionReRollSourceMap, ReRolledActions.SINGLE_BLOCK_DIE, game);
 		}
 
@@ -411,6 +413,9 @@ public class StepBlockRollMultiple extends AbstractStepMultiple {
 					roll.getReRollDiceIndexes());
 			} else if (state.reRollSource == ReRollSources.LORD_OF_CHAOS) {
 				adjustRollForIndexedReRoll(roll, actingPlayer, NamedProperties.canRerollSingleBlockDieOncePerPeriod,
+					roll.getReRollDiceIndexes());
+			} else if (state.reRollSource == ReRollSources.WOODLAND_FURY) {
+				adjustRollForIndexedReRoll(roll, actingPlayer, NamedProperties.canRerollSingleBlockDieWhenWouldBeKnockedDown,
 					roll.getReRollDiceIndexes());
 			} else {
 				roll.setBlockRoll(getGameState().getDiceRoller().rollBlockDice(roll.getNrOfDice()));


### PR DESCRIPTION
Implement Woodland Fury (Star Willow Rosebark): 
* Added knockdown helper.
* Threaded single-block reroll source through client/server (`ClientCommandUseSingleBlockDieReRoll`) to avoid picking the wrong source when multiple skills share `SINGLE_BLOCK_DIE`, and simplifying the handler.
* Works for multiple block.