### PR TITLE
Bug Fix - Bounding Leap (Rowana Forestfoot)

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -9,7 +9,9 @@ public class ChangeList {
 	private final List<VersionChangeList> versions = new ArrayList<>();
 
 	public ChangeList() {
-		versions.add(new VersionChangeList("Future"));
+		versions.add(new VersionChangeList("Future")
+			.addFeature("Bounding Leap (Rowana Forestfoot)")
+		);
 
 		versions.add(new VersionChangeList("2026-02-09")
 			.addBugfix("Apos not sending BH to reserve")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepJump.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepJump.java
@@ -265,7 +265,7 @@ public class StepJump extends AbstractStepWithReRoll {
 			(AgilityMechanic) game.getRules().getFactory(FactoryType.Factory.MECHANIC).forName(Mechanic.Type.AGILITY.name());
 		int minimumRoll = mechanic.minimumRollJump(actingPlayer.getPlayer(), jumpModifiers);
 
-		boolean doRoll = usingDivingTackle == null
+		boolean doRoll = (usingDivingTackle == null || useIgnoreModifierSkill)
 			&& (reRolled  || ((status == null || status == ActionStatus.WAITING_FOR_RE_ROLL) && !dtRerollAsked));
 		if (doRoll) {
 			roll = getGameState().getDiceRoller().rollSkill();


### PR DESCRIPTION
Bounding Leap (Rowana Forestfoot) was unchanged but started autofailing after the Diving Tackle refactor because we set usingDivingTackle to false while only rolling when it’s null, so the jump roll was skipped.