### PR TITLE
Maximum Carnage (Star Max Spleenripper)

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -9,7 +9,9 @@ public class ChangeList {
 	private final List<VersionChangeList> versions = new ArrayList<>();
 
 	public ChangeList() {
-		versions.add(new VersionChangeList("Future"));
+		versions.add(new VersionChangeList("Future")
+			.addFeature("Maximum Carnage (Star Max Spleenripper)")
+		);
 
 		versions.add(new VersionChangeList("2026-02-09")
 			.addBugfix("Apos not sending BH to reserve")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepEndBlocking.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepEndBlocking.java
@@ -427,7 +427,7 @@ public class StepEndBlocking extends AbstractStep {
 						} else if (
 							usingChainsaw && UtilCards.hasUnusedSkillWithProperty(actingPlayer, NamedProperties.canPerformSecondChainsawAttack)
 								&& attackerState.hasTacklezones() && hasValidOtherOpponent &&
-								(blitzWithMoveLeft || actingPlayer.getPlayerAction() == PlayerAction.BLOCK || (actingPlayer.getPlayerAction() == PlayerAction.BLITZ && playerState.isRooted()))
+								(blitzWithMoveLeft || actingPlayer.getPlayerAction() == PlayerAction.CHAINSAW || (actingPlayer.getPlayerAction() == PlayerAction.BLITZ && playerState.isRooted()))
 						) {
 							game.setLastDefenderId(defenderId);
 							UtilServerSteps.changePlayerAction(this, actingPlayer.getPlayerId(), PlayerAction.MAXIMUM_CARNAGE, false);


### PR DESCRIPTION
Skill is unchanged. Wasnt triggering during blocks because chainsaw is now a top level action.