### PR TITLE
Crushing Blow (The Mighty Zug)

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -9,7 +9,9 @@ public class ChangeList {
 	private final List<VersionChangeList> versions = new ArrayList<>();
 
 	public ChangeList() {
-		versions.add(new VersionChangeList("Future"));
+		versions.add(new VersionChangeList("Future")
+			.addFeature("Crushing Blow (The Mighty Zug)")
+		);
 
 		versions.add(new VersionChangeList("2026-02-09")
 			.addBugfix("Apos not sending BH to reserve")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/mixed/CrushingBlowBehaviour.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/mixed/CrushingBlowBehaviour.java
@@ -6,6 +6,7 @@ import com.fumbbl.ffb.server.model.SkillBehaviour;
 import com.fumbbl.ffb.skill.mixed.special.CrushingBlow;
 
 @RulesCollection(RulesCollection.Rules.BB2020)
+@RulesCollection(RulesCollection.Rules.BB2025)
 public class CrushingBlowBehaviour extends SkillBehaviour<CrushingBlow> {
 	public CrushingBlowBehaviour() {
 		super();


### PR DESCRIPTION
Skill is unchanged but the behavior was missing the 2025 annotation.