### PR TITLE
Toxin Connoisseur (Rashnak Backstabber) 

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -9,7 +9,8 @@ public class ChangeList {
 	private final List<VersionChangeList> versions = new ArrayList<>();
 
 	public ChangeList() {
-		versions.add(new VersionChangeList("Future"));
+		versions.add(new VersionChangeList("Future")
+			.addFeature("Toxin Connoisseur (Rashnak Backstabber) - Also works with Violent Innovator"));
 
 		versions.add(new VersionChangeList("2026-02-09")
 			.addBugfix("Apos not sending BH to reserve")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2020/ToxinConnoisseurModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2020/ToxinConnoisseurModification.java
@@ -1,0 +1,35 @@
+package com.fumbbl.ffb.server.injury.modification.bb2020;
+
+import com.fumbbl.ffb.SkillUse;
+import com.fumbbl.ffb.injury.InjuryType;
+import com.fumbbl.ffb.injury.Stab;
+import com.fumbbl.ffb.injury.context.InjuryContext;
+import com.fumbbl.ffb.injury.context.ModifiedInjuryContext;
+import com.fumbbl.ffb.model.Game;
+import com.fumbbl.ffb.server.GameState;
+import com.fumbbl.ffb.server.injury.modification.InjuryContextModification;
+import com.fumbbl.ffb.server.injury.modification.ModificationParams;
+
+import java.util.Collections;
+
+public class ToxinConnoisseurModification extends InjuryContextModification<ModificationParams> {
+
+	public ToxinConnoisseurModification() {
+		super(Collections.singleton(Stab.class));
+	}
+
+	@Override
+	protected ModificationParams params(GameState gameState, ModifiedInjuryContext newContext, InjuryType injuryType) {
+		return new ModificationParams(gameState, newContext, injuryType);
+	}
+
+	@Override
+	protected boolean tryInjuryModification(Game game, InjuryContext injuryContext, InjuryType injuryType) {
+		return !injuryContext.isCasualty();
+	}
+
+	@Override
+	protected SkillUse skillUse() {
+		return SkillUse.ADD_INJURY_MODIFIER;
+	}
+}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/ToxinConnoisseurModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/ToxinConnoisseurModification.java
@@ -1,19 +1,25 @@
-package com.fumbbl.ffb.server.injury.modification;
+package com.fumbbl.ffb.server.injury.modification.bb2025;
 
 import com.fumbbl.ffb.SkillUse;
 import com.fumbbl.ffb.injury.InjuryType;
 import com.fumbbl.ffb.injury.Stab;
+import com.fumbbl.ffb.injury.StabForSpp;
 import com.fumbbl.ffb.injury.context.InjuryContext;
 import com.fumbbl.ffb.injury.context.ModifiedInjuryContext;
 import com.fumbbl.ffb.model.Game;
 import com.fumbbl.ffb.server.GameState;
+import com.fumbbl.ffb.server.injury.modification.InjuryContextModification;
+import com.fumbbl.ffb.server.injury.modification.ModificationParams;
 
-import java.util.Collections;
+import java.util.HashSet;
 
 public class ToxinConnoisseurModification extends InjuryContextModification<ModificationParams> {
 
 	public ToxinConnoisseurModification() {
-		super(Collections.singleton(Stab.class));
+		super(new HashSet<Class<? extends InjuryType>>() {{
+			add(Stab.class);
+			add(StabForSpp.class);
+		}});
 	}
 
 	@Override

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2020/ToxinConnoisseurBehaviour.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2020/ToxinConnoisseurBehaviour.java
@@ -1,0 +1,16 @@
+package com.fumbbl.ffb.server.skillbehaviour.bb2020;
+
+import com.fumbbl.ffb.RulesCollection;
+import com.fumbbl.ffb.server.injury.modification.bb2020.ToxinConnoisseurModification;
+import com.fumbbl.ffb.server.model.SkillBehaviour;
+import com.fumbbl.ffb.skill.mixed.special.ToxinConnoisseur;
+
+@RulesCollection(RulesCollection.Rules.BB2020)
+public class ToxinConnoisseurBehaviour extends SkillBehaviour<ToxinConnoisseur> {
+
+	public ToxinConnoisseurBehaviour() {
+		super();
+
+		registerModifier(new ToxinConnoisseurModification());
+	}
+}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/ToxinConnoisseurBehaviour.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/ToxinConnoisseurBehaviour.java
@@ -1,11 +1,10 @@
-package com.fumbbl.ffb.server.skillbehaviour.mixed;
+package com.fumbbl.ffb.server.skillbehaviour.bb2025;
 
 import com.fumbbl.ffb.RulesCollection;
-import com.fumbbl.ffb.server.injury.modification.ToxinConnoisseurModification;
+import com.fumbbl.ffb.server.injury.modification.bb2025.ToxinConnoisseurModification;
 import com.fumbbl.ffb.server.model.SkillBehaviour;
 import com.fumbbl.ffb.skill.mixed.special.ToxinConnoisseur;
 
-@RulesCollection(RulesCollection.Rules.BB2020)
 @RulesCollection(RulesCollection.Rules.BB2025)
 public class ToxinConnoisseurBehaviour extends SkillBehaviour<ToxinConnoisseur> {
 


### PR DESCRIPTION
Toxin Connoisseur (Rashnak Backstabber). Skill was wired correctly except when player had Violent Innovator.