### PR TITLE
Bug Fix - Savage Mauling

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -13,6 +13,7 @@ public class ChangeList {
 			.addBugfix("Whirling Dervish can only be used once")
 			.addBugfix("B&C prevents Secure the Ball")
 			.addBugfix("\"Kick'em while they're down\" as blitz version is working again")
+			.addBugfix("Savage Mauling reports injury only once")
 		);
 
 		versions.add(new VersionChangeList("2026-02-12")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/mechanic/bb2025/StateMechanic.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/mechanic/bb2025/StateMechanic.java
@@ -141,7 +141,7 @@ public class StateMechanic extends com.fumbbl.ffb.server.mechanic.StateMechanic 
 		if (injuryContext instanceof ModifiedInjuryContext) {
 			InjuryModification modification = ((ModifiedInjuryContext) injuryContext).getModification();
 			if (modification == InjuryModification.INJURY) {
-				skip = injuryResult.isPreRegeneration() ? SkipInjuryParts.ARMOUR_AND_CAS : SkipInjuryParts.ARMOUR;
+				skip = injuryResult.isPreRegeneration() ? SkipInjuryParts.ARMOUR_AND_CAS : SkipInjuryParts.EVERYTHING_BUT_CAS;
 			}
 		} else if (injuryContext.getModifiedInjuryContext() != null) {
 			InjuryModification modification = injuryContext.getModifiedInjuryContext().getModification();


### PR DESCRIPTION
Fixed an issue where Savage Mauling was reporting the injury twice. It wasn't specific to Savage Mauling, it affected modified injury reporting generally.
