### PR TITLE
Bug Fix - Team ReRoll during a block

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -15,6 +15,7 @@ public class ChangeList {
 			.addBugfix("Savage Mauling reports injury only once")
 			.addBugfix("Team Captain needs to be on the pitch to save re-roll")
 			.addBugfix("Thinking Man's Troll re-rolled whole dice pool on regular blocks")
+			.addBugfix("Using Team RR during a block no longer crashes the game")
 		);
 
 		versions.add(new VersionChangeList("2026-02-12")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepBlockRoll.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepBlockRoll.java
@@ -236,9 +236,11 @@ public class StepBlockRoll extends AbstractStepWithReRoll {
 			actingPlayer.markSkillUsed(addDieSkill.get());
 		}
 
+		Skill reRollSkill = getReRollSource() != null ? getReRollSource().getSkill(game) : null;
+
 		if (getReRollSource() == ReRollSources.PRO ||
-			(getReRollSource() != null &&
-				getReRollSource().getSkill(game).hasSkillProperty(NamedProperties.canRerollSingleDieOncePerPeriod))) {
+			(reRollSkill != null &&
+				reRollSkill.hasSkillProperty(NamedProperties.canRerollSingleDieOncePerPeriod))) {
 			if (getReRollSource() == ReRollSources.PRO) {
 				actingPlayer.markSkillUsed(NamedProperties.canRerollOncePerTurn);
 			}


### PR DESCRIPTION
Thinking Man's Troll fix introduced a new bug:
Using Team ReRoll during a block set `reRollSource` to `TEAM_RE_ROLL`, the reroll path then called `getSkill(game).hasSkillProperty` but `getSkill(game)` is null for Team ReRoll, causing an NPE.