### PR TITLE
Bug Fix - Hypnotic Gaze after rush

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -14,6 +14,7 @@ public class ChangeList {
 			.addBugfix("Stalling: No stalling did not grant cash bonus")
 			.addImprovement("Stalling: On turn 7+ do not roll for stalling")
 			.addBugfix("Do not offer Forgo for prone players")
+			.addBugfix("Hypnotic Gaze: rushing twice would end activation before selecting the target")
 		);
 
 		versions.add(new VersionChangeList("3.0.0")

--- a/ffb-common/src/main/java/com/fumbbl/ffb/util/UtilPlayer.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/util/UtilPlayer.java
@@ -485,6 +485,11 @@ public class UtilPlayer {
 		return false;
 	}
 
+	public static boolean hasAdjacentGazeTarget(Game game, Player<?> player) {
+		FieldCoordinate playerCoordinate = game.getFieldModel().getPlayerCoordinate(player);
+		Team otherTeam = UtilPlayer.findOtherTeam(game, player);
+		return UtilPlayer.findAdjacentPlayersWithTacklezones(game, otherTeam, playerCoordinate, false).length > 0;
+	}
 
 	public static boolean canFoul(Game pGame, Player<?> pPlayer) {
 		FieldModel fieldModel = pGame.getFieldModel();

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepEndMoving.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepEndMoving.java
@@ -267,7 +267,7 @@ public class StepEndMoving extends AbstractStep {
 				|| ((PlayerAction.PASS_MOVE == playerAction) && UtilPlayer.hasBall(game, actingPlayer.getPlayer()))
 				|| ((PlayerAction.FOUL_MOVE == playerAction) && UtilPlayer.canFoul(game, actingPlayer.getPlayer()))
 				|| ((PlayerAction.GAZE_MOVE == playerAction) &&
-				UtilPlayer.isNextToGazeTarget(game, actingPlayer.getPlayer()))
+				UtilPlayer.hasAdjacentGazeTarget(game, actingPlayer.getPlayer()))
 				|| ((PlayerAction.KICK_TEAM_MATE_MOVE == playerAction) &&
 				UtilPlayer.canKickTeamMate(game, actingPlayer.getPlayer(), false))
 				|| ((PlayerAction.THROW_TEAM_MATE_MOVE == playerAction) &&


### PR DESCRIPTION

`GAZE_MOVE` in BB2025 wrongly checks `isNextToGazeTarget()` (which requires an already-selected target), so after the second Rush it can end activation before target selection. 
Fixed by introducing `UtilPlayer.hasAdjacentGazeTarget()` and gating continuation on adjacent legal gaze victims instead of preselected `TargetSelectionState`.