### PR TITLE
Bug Fix - Strip Ball when pushback is canceled by Stand Firm/Take Root

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -19,6 +19,7 @@ public class ChangeList {
 			.addBugfix("Brilliant Coaching: Tied result did give no re-roll to either team")
 			.addImprovement("iron Man: Only players with AV 10+ or less are eligible")
 			.addBugfix("Under Scrutiny: Only triggers for av breaks")
+			.addBugfix("Stripball: no longer works against Stand Firm/Rooted players")
 		);
 
 		versions.add(new VersionChangeList("3.0.0")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/StandFirmBehaviour.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/StandFirmBehaviour.java
@@ -69,6 +69,8 @@ public class StandFirmBehaviour extends SkillBehaviour<StandFirm> {
 						state.pushbackStack.clear();
 						step.publishParameter(new StepParameter(StepParameterKey.STARTING_PUSHBACK_SQUARE, null));
 						step.publishParameter(new StepParameter(StepParameterKey.FOLLOWUP_CHOICE, false));
+						step.publishParameter(new StepParameter(StepParameterKey.BALL_KNOCKED_LOSE, false));
+						step.publishParameter(new StepParameter(StepParameterKey.CATCH_SCATTER_THROW_IN_MODE, null));
 						step.getResult().addReport(new ReportSkillUse(state.defender.getId(), skill, true, SkillUse.AVOID_PUSH));
 					}
 

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/TakeRootBehaviour.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/TakeRootBehaviour.java
@@ -101,6 +101,8 @@ public class TakeRootBehaviour extends SkillBehaviour<TakeRoot> {
 					state.pushbackStack.clear();
 					step.publishParameter(new StepParameter(StepParameterKey.STARTING_PUSHBACK_SQUARE, null));
 					step.publishParameter(new StepParameter(StepParameterKey.FOLLOWUP_CHOICE, false));
+					step.publishParameter(new StepParameter(StepParameterKey.BALL_KNOCKED_LOSE, false));
+					step.publishParameter(new StepParameter(StepParameterKey.CATCH_SCATTER_THROW_IN_MODE, null));
 					return true;
 				}
 


### PR DESCRIPTION
In BB2025, Strip Ball was armed at block-choice time (`BALL_KNOCKED_LOSE=true`, `CATCH_SCATTER_THROW_IN_MODE=SCATTER_BALL`) and could still resolve even when pushback was later canceled by Stand Firm or Take Root (already rooted).

Disarm now publishes:
BALL_KNOCKED_LOSE=false
CATCH_SCATTER_THROW_IN_MODE=null
