### PR TITLE
Bug Fix - Prone Hypnotic Gaze with failed Bloodlust

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -26,6 +26,7 @@ public class ChangeList {
 			.addImprovement("TTM and KTM: reroll choice for Subpar results")
 			.addBugfix("Solid Defence: During player selection it was able to move players around")
 			.addBugfix("Permanent injuries were not removed by regeneration")
+			.addBugfix("Hypnotic Gaze + Bloodlust: prone players now can move/feed after failed Bloodlust instead of auto-gazing and ending activation")
 		);
 
 		versions.add(new VersionChangeList("3.0.0")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepEndSelecting.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepEndSelecting.java
@@ -258,6 +258,8 @@ public final class StepEndSelecting extends AbstractStep {
           }
         } else if (fDispatchPlayerAction == PlayerAction.BLITZ) {
           UtilServerSteps.changePlayerAction(this, actingPlayer.getPlayerId(), fDispatchPlayerAction, actingPlayer.isJumping());
+        } else if (fDispatchPlayerAction == PlayerAction.GAZE) {
+          fGazeVictimId = null;
         }
 
         dispatchPlayerAction(fDispatchPlayerAction, bloodlustAction == null || !fDispatchPlayerAction.isMoving());


### PR DESCRIPTION
We were still carrying the previously clicked gaze target after a failed Bloodlust in the prone flow.
So when the action got sent back into move handling, the code saw that saved target and immediately fired Hypnotic Gaze.

This fix works and is low impact, but could be cleaned up further by removing preselected-gaze-target plumbing entirely and relying only on GAZE_MOVE flow (a lot more involved and prone to bugs).