### PR TITLE
Fix bb2025 StepEndFouling wrong Move import and DodgeModifierFactory NPE

### DIFF
--- a/ffb-common/src/main/java/com/fumbbl/ffb/factory/DodgeModifierFactory.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/factory/DodgeModifierFactory.java
@@ -56,15 +56,16 @@ public class DodgeModifierFactory extends GenerifiedModifierFactory<DodgeContext
 	public Set<DodgeModifier> findModifiers(DodgeContext context) {
 		Set<DodgeModifier> dodgeModifiers = super.findModifiers(context);
 
-		prehensileTailModifier(findNumberOfPrehensileTails(context.getGame(), context.getSourceCoordinate()))
+		prehensileTailModifier(findNumberOfPrehensileTails(context.getGame(), context.getActingPlayer(), context.getSourceCoordinate()))
 			.ifPresent(dodgeModifiers::add);
 
 		return dodgeModifiers;
 	}
 
-	private int findNumberOfPrehensileTails(Game pGame, FieldCoordinate pCoordinateFrom) {
-		ActingPlayer actingPlayer = pGame.getActingPlayer();
-		Team otherTeam = UtilPlayer.findOtherTeam(pGame, actingPlayer.getPlayer());
+	private int findNumberOfPrehensileTails(Game pGame, ActingPlayer actingPlayer, FieldCoordinate pCoordinateFrom) {
+		Player<?> actingPlayerRef = (actingPlayer != null) ? actingPlayer.getPlayer() : null;
+		if (actingPlayerRef == null) return 0;
+		Team otherTeam = UtilPlayer.findOtherTeam(pGame, actingPlayerRef);
 		int nrOfPrehensileTails = 0;
 		Player<?>[] opponents = UtilPlayer.findAdjacentPlayersWithTacklezones(pGame, otherTeam, pCoordinateFrom, true);
 		for (Player<?> opponent : opponents) {

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/foul/StepEndFouling.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/foul/StepEndFouling.java
@@ -23,7 +23,7 @@ import com.fumbbl.ffb.server.step.UtilServerSteps;
 import com.fumbbl.ffb.server.step.generator.EndPlayerAction;
 import com.fumbbl.ffb.server.step.generator.Select;
 import com.fumbbl.ffb.server.step.generator.SequenceGenerator;
-import com.fumbbl.ffb.server.step.generator.bb2020.Move;
+import com.fumbbl.ffb.server.step.generator.bb2025.Move;
 import com.fumbbl.ffb.util.UtilPlayer;
 
 /**


### PR DESCRIPTION
I ran 1000 simulated BB2025 games with semi-random bot behaviour and ran
into what I believe are two bugs in the game logic, but I am not sure
since I am still unfamiliar with the code. I thought I'd report it in
any case.

### Post-foul move sequence uses BB2020 logic in BB2025 games

After a foul in a BB2025 game, if the fouling player wasn't ejected,
the game enters a move sequence to continue the turn. Due to a wrong
import, this sequence was driven by the BB2020 Move generator instead
of the BB2025 one — meaning post-foul movement in BB2025 games silently
applied BB2020 rules.

`StepEndFouling` lives in the `bb2025` package but imported
`step.generator.bb2020.Move` instead of `step.generator.bb2025.Move`.
One-line fix.

### Game crashes computing Prehensile Tail penalty when no player is active

When reachable squares are updated (e.g. in `StepHandleDropPlayerContext`
or `StepInitSelecting`), the server computes dodge modifiers for each
candidate square including any Prehensile Tail penalty. In these steps no
player activation is formally in progress, so `game.getActingPlayer()` can
return null. `DodgeModifierFactory.findNumberOfPrehensileTails()` called
`getActingPlayer().getPlayer()` unconditionally, causing a
NullPointerException.

Fixed by passing `actingPlayer` as an explicit parameter from the
`DodgeContext` and guarding against null before dereferencing it.