### PR TITLE
Add missing Zoat and Spite keywords

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -23,6 +23,7 @@ public class ChangeList {
 			.addBugfix("With JVMs newer than 8, range rulers did not show the required roll anymore")
 			.addBugfix("Gaining additional Hatred results in duplication of existing Hatred skill listings")
 			.addBugfix("Bloodlust: When opting to move instead of fouling directly due to failed Bloodlust the game crashed")
+			.addBugfix("Missing Zoat and Spite keywords caused Hatred/Getting Even to show Unknown")
 		);
 
 		versions.add(new VersionChangeList("3.2.2")

--- a/ffb-common/src/main/java/com/fumbbl/ffb/model/Keyword.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/model/Keyword.java
@@ -36,6 +36,7 @@ public enum Keyword {
 	SNOTLING("Snotling"),
 	SPAWN("Spawn"),
 	SPECIAL("Special", false),
+	SPITE("Spite"),
 	SQUIRREL("Squirrel"),
 	THRALL("Thrall"),
 	THROWER("Thrower", false),
@@ -46,6 +47,7 @@ public enum Keyword {
 	WEREWOLF("Werewolf"),
 	WRAITH("Wraith"),
 	YHETEE("Yhetee"),
+	ZOAT("Zoat"),
 	ZOMBIE("Zombie"),
 
 	// fallback


### PR DESCRIPTION
Adds the missing `Zoat` (Zolcath the Zoat) and `Spite` (Swiftvine Glimmershard) keywords to prevent `Getting Even` / `Hatred` from using `Unknown` for those players.

Ran into this in a game involving a `Zoat` and fixed it while I was there; a quick check showed `Spite` was missing as well.