### PR TITLE
Dwarfen Grit (Star Josef Bugman)

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -24,6 +24,7 @@ public class ChangeList {
 			.addBugfix("Gaining additional Hatred results in duplication of existing Hatred skill listings")
 			.addBugfix("Bloodlust: When opting to move instead of fouling directly due to failed Bloodlust the game crashed")
 			.addBugfix("Missing Zoat and Spite keywords caused Hatred/Getting Even to show Unknown")
+			.addFeature("Dwarfen Grit (Star Josef Bugman")
 		);
 
 		versions.add(new VersionChangeList("3.2.2")

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -24,7 +24,7 @@ public class ChangeList {
 			.addBugfix("Gaining additional Hatred results in duplication of existing Hatred skill listings")
 			.addBugfix("Bloodlust: When opting to move instead of fouling directly due to failed Bloodlust the game crashed")
 			.addBugfix("Missing Zoat and Spite keywords caused Hatred/Getting Even to show Unknown")
-			.addFeature("Dwarfen Grit (Star Josef Bugman")
+			.addFeature("Dwarfen Grit (Star Josef Bugman)")
 		);
 
 		versions.add(new VersionChangeList("3.2.2")

--- a/ffb-common/src/main/java/com/fumbbl/ffb/injury/context/IInjuryContextModification.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/injury/context/IInjuryContextModification.java
@@ -2,4 +2,8 @@ package com.fumbbl.ffb.injury.context;
 
 public interface IInjuryContextModification {
 	boolean requiresConditionalReRollSkill();
+
+	default boolean appliesToDefender() {
+		return false;
+	}
 }

--- a/ffb-common/src/main/java/com/fumbbl/ffb/skill/bb2025/special/DwarfenGrit.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/skill/bb2025/special/DwarfenGrit.java
@@ -1,0 +1,18 @@
+package com.fumbbl.ffb.skill.bb2025.special;
+
+import com.fumbbl.ffb.RulesCollection;
+import com.fumbbl.ffb.RulesCollection.Rules;
+import com.fumbbl.ffb.SkillCategory;
+import com.fumbbl.ffb.model.skill.Skill;
+import com.fumbbl.ffb.model.skill.SkillUsageType;
+
+/**
+ * Once per game, when Josef’s armour is broken as the result of an Armour Roll,
+ * you may choose to have the Armour Roll re-rolled.
+ */
+@RulesCollection(Rules.BB2025)
+public class DwarfenGrit extends Skill {
+  public DwarfenGrit() {
+    super("Dwarfen Grit", SkillCategory.TRAIT, SkillUsageType.ONCE_PER_GAME);
+  }
+}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/ModificationAwareInjuryTypeServer.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/ModificationAwareInjuryTypeServer.java
@@ -35,26 +35,39 @@ public abstract class ModificationAwareInjuryTypeServer<T extends InjuryType> ex
 
 		Optional<IInjuryContextModification> modification = Optional.empty();
 		if (pAttacker != null) {
-			modification = pAttacker.getUnusedInjuryModification(injuryType);
+			modification = pAttacker.getUnusedInjuryModification(injuryType).filter(mod -> !mod.appliesToDefender());
 		} else if (injuryType.isChainsaw() || injuryType.isVomitLike()) {
-			modification = pDefender.getUnusedInjuryModification(injuryType);
+			modification = pDefender.getUnusedInjuryModification(injuryType).filter(mod -> !mod.appliesToDefender());
 		}
 
 		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
 
 		armourRoll(game, gameState, diceRoller, pAttacker, pDefender, diceInterpreter, injuryContext, true);
 
+		boolean modified = false;
+
 		if (modification.isPresent()) {
-			boolean modified = ((InjuryContextModification<? extends ModificationParams>) modification.get()).modifyArmour(gameState, injuryContext, injuryType);
+			modified = ((InjuryContextModification<? extends ModificationParams>) modification.get())
+				.modifyArmour(gameState, injuryContext, injuryType);
+		}
 
-			if (modified) {
-				ModifiedInjuryContext alternateInjuryContext = injuryContext.getModifiedInjuryContext();
-				alternateInjuryContext.setArmorBroken(false);
-				armourRoll(game, gameState, diceRoller, pAttacker, pDefender, diceInterpreter, alternateInjuryContext, false);
+		if (!modified && injuryContext.isArmorBroken()) {
+			Optional<IInjuryContextModification> defenderModification = pDefender.getUnusedInjuryModification(injuryType)
+				.filter(mod -> mod.appliesToDefender());
 
-				injury(game, gameState, diceRoller, pAttacker, pDefender, Optional.empty(), alternateInjuryContext);
-
+			if (defenderModification.isPresent()) {
+				modification = defenderModification;
+				modified = ((InjuryContextModification<? extends ModificationParams>) modification.get())
+					.modifyArmour(gameState, injuryContext, injuryType);
 			}
+		}
+
+		if (modified) {
+			ModifiedInjuryContext alternateInjuryContext = injuryContext.getModifiedInjuryContext();
+			alternateInjuryContext.setArmorBroken(false);
+			armourRoll(game, gameState, diceRoller, pAttacker, pDefender, diceInterpreter, alternateInjuryContext, false);
+
+			injury(game, gameState, diceRoller, pAttacker, pDefender, Optional.empty(), alternateInjuryContext);
 		}
 
 		injury(game, gameState, diceRoller, pAttacker, pDefender, modification, injuryContext);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/InjuryContextModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/InjuryContextModification.java
@@ -117,6 +117,10 @@ public abstract class InjuryContextModification<T extends ModificationParams> im
 		return false;
 	}
 
+	public boolean appliesToDefender() {
+		return false;
+	}
+
 	protected abstract SkillUse skillUse();
 
 	public boolean isValidType(InjuryType injuryType) {

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/DwarfenGritModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/DwarfenGritModification.java
@@ -1,0 +1,24 @@
+package com.fumbbl.ffb.server.injury.modification.bb2025;
+
+import com.fumbbl.ffb.injury.Block;
+import com.fumbbl.ffb.injury.InjuryType;
+import com.fumbbl.ffb.server.injury.modification.ModificationParams;
+
+import java.util.Collections;
+
+public class DwarfenGritModification extends RerollArmourModification {
+
+	public DwarfenGritModification() {
+		super(Collections.<Class<? extends InjuryType>>singleton(Block.class));
+	}
+
+	@Override
+	protected boolean tryArmourRollModification(ModificationParams params) {
+		return params.getNewContext().isArmorBroken();
+	}
+
+	@Override
+	public boolean appliesToDefender() {
+		return true;
+	}
+}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/DwarfenGritBehaviour.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/DwarfenGritBehaviour.java
@@ -1,0 +1,15 @@
+package com.fumbbl.ffb.server.skillbehaviour.bb2025;
+
+import com.fumbbl.ffb.RulesCollection;
+import com.fumbbl.ffb.server.injury.modification.bb2025.DwarfenGritModification;
+import com.fumbbl.ffb.server.model.SkillBehaviour;
+import com.fumbbl.ffb.skill.bb2025.special.DwarfenGrit;
+
+@RulesCollection(RulesCollection.Rules.BB2025)
+public class DwarfenGritBehaviour extends SkillBehaviour<DwarfenGrit> {
+
+	public DwarfenGritBehaviour() {
+		super();
+		registerModifier(new DwarfenGritModification());
+	}
+}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepHandleDropPlayerContext.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepHandleDropPlayerContext.java
@@ -129,8 +129,14 @@ public class StepHandleDropPlayerContext extends AbstractStepWithReRoll {
 			if (injuryResult.injuryContext().getModifiedInjuryContext() != null && !injuryResult.isAlreadyReported()) {
 				injuryResult.report(this);
 				ModifiedInjuryContext injuryContext = injuryResult.injuryContext().getModifiedInjuryContext();
-				playerId = game.getActingPlayer().getPlayerId();
 				skill = injuryContext.getUsedSkill();
+
+				if (skill.getSkillBehaviour().getInjuryContextModification().appliesToDefender()) {
+					playerId = game.getPlayerById(injuryContext.fDefenderId).getId();
+				} else {
+					playerId = game.getActingPlayer().getPlayerId();
+				}
+
 				UtilServerDialog.showDialog(getGameState(), new DialogSkillUseParameter(playerId, skill, 0), true);
 				getResult().setNextAction(StepAction.CONTINUE);
 			} else {


### PR DESCRIPTION
Added support for BB2025 Dwarfen Grit (Star Josef Bugman)
- Allows defender-side injury context modifications to prompt the defender
- Enforces one reroll per armour roll, so Dwarfen Grit is not available after another armour reroll has been used

_Note: This does not include Josef Bugman's Infamous Coaching Staff inducement effects_

