### PR TITLE
Bug Fix - Preserve emoji picker when toggling replay mode

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -133,6 +133,7 @@ public class ChangeList {
 			.addBugfix("Support multiple cheering fans assist per team")
 			.addBugfix("Ensure only players in reserves can be selected for prayers")
 			.addFeature("Support icon set index for player icons")
+			.addBugfix("Emoji picker disappeared after switching between spectator and replay mode")
 		);
 
 		versions.add(new VersionChangeList("3.0.0")

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatComponent.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatComponent.java
@@ -48,6 +48,7 @@ public class ChatComponent extends JPanel implements MouseMotionListener {
 	private Autocomplete autocomplete;
 	private final IconCache iconCache;
 	private final ChatButtonComponent fChatButtonComponent;
+	private final JComponent fChatInputPanel;
 
 	public ChatComponent(FantasyFootballClient pClient, UiDimensionProvider dimensionProvider, StyleProvider styleProvider, IconCache iconCache) {
 
@@ -141,7 +142,8 @@ public class ChatComponent extends JPanel implements MouseMotionListener {
 		add(fChatScrollPane, BorderLayout.CENTER);
 		
 		fChatButtonComponent = new ChatButtonComponent(fClient, fChatInputField, dimensionProvider, iconCache);
-		add(buildChatInputPanel(), BorderLayout.SOUTH);
+		fChatInputPanel = buildChatInputPanel();
+		add(fChatInputPanel, BorderLayout.SOUTH);
 
 		fChatTextPane.addMouseMotionListener(this);
 		fChatScrollPane.addMouseMotionListener(this);
@@ -202,7 +204,7 @@ public class ChatComponent extends JPanel implements MouseMotionListener {
 			add(fReplayControl, BorderLayout.NORTH);
 		}
 		add(fChatScrollPane, BorderLayout.CENTER);
-		add(fChatInputField, BorderLayout.SOUTH);
+		add(fChatInputPanel, BorderLayout.SOUTH);
 		revalidate();
 		repaint();
 		fReplayShown = pShowReplay;


### PR DESCRIPTION
Fix spectator/replay chat panel rebuild so the wrapped chat input, including the emoji picker button, is preserved when entering and leaving replay mode.