### PR TITLE
Bug Fix - Reset button blocking star hires

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/inducements/StarPlayerTableModel.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/inducements/StarPlayerTableModel.java
@@ -96,7 +96,7 @@ public class StarPlayerTableModel extends AbstractTableModel {
 							fDialog.recalculateGold();
 							fNrOfCheckedRows = getCheckedRows();
 						}
-					} else {
+					} else if ((Boolean) fRowData[pRowIndex][pColumnIndex]) {
 						fRowData[pRowIndex][pColumnIndex] = false;
 						fireTableCellUpdated(pRowIndex, pColumnIndex);
 						fRowData[partnerRowId][pColumnIndex] = false;

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -24,6 +24,7 @@ public class ChangeList {
 			.addBugfix("Gaining additional Hatred results in duplication of existing Hatred skill listings")
 			.addBugfix("Bloodlust: When opting to move instead of fouling directly due to failed Bloodlust the game crashed")
 			.addBugfix("Missing Zoat and Spite keywords caused Hatred/Getting Even to show Unknown")
+			.addBugfix("Reset button could block hiring star players")
 		);
 
 		versions.add(new VersionChangeList("3.2.2")


### PR DESCRIPTION
Found while working on Bugman. Keeping it separate to keep the Bugman PR cleaner.

Resetting inducements cleared paired star rows as if they had been actively deselected, which also reduced the internal star limit. That could leave the dialog in a bad state where star hires were no longer possible afterward.

The fix makes the paired-star deselection logic run only when the row was actually selected.