### PR TITLE
Bug Fix - Fumblerooski Self Foul

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -24,6 +24,7 @@ public class ChangeList {
 			.addBugfix("Gaining additional Hatred results in duplication of existing Hatred skill listings")
 			.addBugfix("Bloodlust: When opting to move instead of fouling directly due to failed Bloodlust the game crashed")
 			.addBugfix("Missing Zoat and Spite keywords caused Hatred/Getting Even to show Unknown")
+			.addBugfix("Selecting Fumblerooskie during a foul action could foul the active player instead")
 		);
 
 		versions.add(new VersionChangeList("3.2.2")

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/IPlayerPopupMenuKeys.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/IPlayerPopupMenuKeys.java
@@ -25,8 +25,7 @@ public interface IPlayerPopupMenuKeys {
 
 	int KEY_FORGO = KeyEvent.VK_F;
 	int KEY_FOUL = KeyEvent.VK_F;
-	int KEY_FUMBLEROOSKIE = KeyEvent.VK_F;
-
+	
 	int KEY_GAZE = KeyEvent.VK_G;
 
 	int KEY_HAIL_MARY_PASS = KeyEvent.VK_H;
@@ -92,4 +91,8 @@ public interface IPlayerPopupMenuKeys {
 	int KEY_CHOMP = KeyEvent.VK_1;
 
 	int KEY_RAIDING_PARTY = KeyEvent.VK_2;
+
+
+
+	int KEY_FUMBLEROOSKIE = KeyEvent.VK_4;
 }

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/bb2025/FoulLogicModule.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/bb2025/FoulLogicModule.java
@@ -96,6 +96,7 @@ public class FoulLogicModule extends MoveLogicModule {
       add(ClientAction.BLACK_INK);
       add(ClientAction.AUTO_GAZE_ZOAT);
       add(ClientAction.INCORPOREAL);
+      add(ClientAction.FUMBLEROOSKIE);
     }};
   }
 
@@ -184,7 +185,12 @@ public class FoulLogicModule extends MoveLogicModule {
             boolean incorporealActive = actingPlayer.getPlayer().hasActiveEnhancement(skill);
             communication.sendUseSkill(skill, !incorporealActive, actingPlayer.getPlayer().getId());
           }
-          break;  
+          break;
+        case FUMBLEROOSKIE:
+          if (isFumblerooskieAvailable()) {
+            communication.sendUseFumblerooskie();
+          }
+          break;
         default:
           break;
       }

--- a/ffb-client/src/main/java/com/fumbbl/ffb/client/state/bb2025/ClientStateFoul.java
+++ b/ffb-client/src/main/java/com/fumbbl/ffb/client/state/bb2025/ClientStateFoul.java
@@ -114,6 +114,7 @@ public class ClientStateFoul extends AbstractClientStateMove<FoulLogicModule> {
       put(IPlayerPopupMenuKeys.KEY_BOUNDING_LEAP, ClientAction.BOUNDING_LEAP);
       put(IPlayerPopupMenuKeys.KEY_AUTO_GAZE_ZOAT, ClientAction.AUTO_GAZE_ZOAT);
       put(IPlayerPopupMenuKeys.KEY_INCORPOREAL, ClientAction.INCORPOREAL);
+      put(IPlayerPopupMenuKeys.KEY_FUMBLEROOSKIE, ClientAction.FUMBLEROOSKIE);
     }};
   }
 


### PR DESCRIPTION
Fix for [this bug](https://fumbbl.com/p/bugs?id/4555)

- Fumblerooskie used the same popup key as Foul, so selecting it during a foul action could foul the active player instead.
- Changed Fumblerooskie to use `4`; `3` is already used in the I'll Carry You PR.
- Wired Fumblerooskie into the foul action flow since it was also missing.