### PR TITLE
Bug Fix - Master Assassin not applying injury after a successful armour re-roll.

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -24,6 +24,7 @@ public class ChangeList {
 			.addBugfix("Gaining additional Hatred results in duplication of existing Hatred skill listings")
 			.addBugfix("Bloodlust: When opting to move instead of fouling directly due to failed Bloodlust the game crashed")
 			.addBugfix("Missing Zoat and Spite keywords caused Hatred/Getting Even to show Unknown")
+			.addBugfix("Master Assassin: Re-rolled Stab armour breaks did not apply the resulting injury")
 		);
 
 		versions.add(new VersionChangeList("3.2.2")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeStab.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeStab.java
@@ -44,7 +44,7 @@ public class InjuryTypeStab extends ModificationAwareInjuryTypeServer<Stab> {
 				pDefender, isStab(), isFoul(), isVomitLike());
 			injuryContext.addInjuryModifiers(injuryModifiers);
 		}
-		setInjury(pDefender, gameState, diceRoller);
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 
 	@Override

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeStabForSpp.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeStabForSpp.java
@@ -44,7 +44,7 @@ public class InjuryTypeStabForSpp extends ModificationAwareInjuryTypeServer<Stab
 				pDefender, isStab(), isFoul(), isVomitLike());
 			injuryContext.addInjuryModifiers(injuryModifiers);
 		}
-		setInjury(pDefender, gameState, diceRoller);
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 
 	@Override


### PR DESCRIPTION
Fix for [this bug report](https://fumbbl.com/p/bugs?id/4547)

BB2025 Master Assassin creates a modified context for the armor re-roll, but Stab was resolving the injury on the original context. 