### PR TITLE
Grab no longer cancels sidestep during a blitz

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -17,6 +17,7 @@ public class ChangeList {
 			.addFeature("Infamous Staff - Josef Bugman")
 			.addBugfix("Reset button could block hiring star players")
 			.addBugfix("Emoji picker disappeared after switching between spectator and replay mode")
+			.addBugfix("Grab no longer cancels Sidestep during a Blitz, matching the 2025 FAQ")
 		);
 
 		versions.add(new VersionChangeList("3.2.3")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/SidestepBehaviour.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/skillbehaviour/bb2025/SidestepBehaviour.java
@@ -41,7 +41,7 @@ public class SidestepBehaviour extends SkillBehaviour<Sidestep> {
 				Game game = step.getGameState().getGame();
 				ActingPlayer actingPlayer = game.getActingPlayer();
 				Skill cancellingSkill = null;
-				if (state.defender.getId().equals(game.getDefenderId())) {
+				if (state.defender.getId().equals(game.getDefenderId()) && !actingPlayer.getPlayerAction().isBlitzing()) {
 					cancellingSkill = UtilCards.getSkillCancelling(actingPlayer.getPlayer(), skill);
 				}
 				boolean attackerHasConflictingSkill = cancellingSkill != null && cancellingSkill.conflictsWithAnySkill(actingPlayer.getPlayer());


### PR DESCRIPTION
Update BB2025 Sidestep handling so Grab does not cancel it during Blitz actions as per May 2026 FAQ.