### PR TITLE
Fix for stale list of teametups after removing one of team set up on client.

### DIFF
--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/db/DbTransaction.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/db/DbTransaction.java
@@ -104,14 +104,22 @@ public class DbTransaction implements IDbUpdateParameter {
 	@Override
 	public void doAfterCommit(FantasyFootballServer pServer) {
 		if (afterCommitCallback != null) {
-			afterCommitCallback.run();
+			try {
+				afterCommitCallback.run();
+			} catch (Exception e) {
+				pServer.getDebugLog().logWithOutGameId(e);
+			}
 		}
 	}
 
 	@Override
 	public void doAfterRollback(FantasyFootballServer pServer) {
 		if (afterRollbackCallback != null) {
-			afterRollbackCallback.run();
+			try {
+				afterRollbackCallback.run();
+			} catch (Exception e) {
+				pServer.getDebugLog().logWithOutGameId(e);
+			}
 		}
 	}
 

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/db/DbTransaction.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/db/DbTransaction.java
@@ -15,9 +15,23 @@ public class DbTransaction implements IDbUpdateParameter {
 
 	private int fUpdatedRows;
 	private final List<IDbUpdateParameter> fDbUpdateParameters;
+	private Runnable afterCommitCallback;
+	private Runnable afterRollbackCallback;
 
 	public DbTransaction() {
 		fDbUpdateParameters = new ArrayList<>();
+	}
+
+	public DbTransaction(Runnable afterCommitCallback, Runnable afterRollBackCallback) {
+		this();
+		this.afterCommitCallback = afterCommitCallback;
+		this.afterRollbackCallback = afterRollBackCallback;
+	}
+
+	public DbTransaction(Runnable afterCommitOrAfterRollbackCallback) {
+		this();
+		this.afterCommitCallback = afterCommitOrAfterRollbackCallback;
+		this.afterRollbackCallback = afterCommitOrAfterRollbackCallback;
 	}
 
 	public void add(IDbUpdateParameter pDbUpdateParameter) {
@@ -68,9 +82,11 @@ public class DbTransaction implements IDbUpdateParameter {
 		try {
 			if (doCommit) {
 				pServer.getDbUpdateFactory().commit();
+				doAfterCommit(pServer);
 			} else {
 				fUpdatedRows = 0;
 				pServer.getDbUpdateFactory().rollback();
+				doAfterRollback(pServer);
 			}
 		} catch (SQLException pCommitException) {
 			pServer.getDebugLog().logWithOutGameId(pCommitException);
@@ -83,6 +99,20 @@ public class DbTransaction implements IDbUpdateParameter {
 
 	public DbUpdateStatement getDbUpdateStatement(FantasyFootballServer pServer) {
 		return null;
+	}
+
+	@Override
+	public void doAfterCommit(FantasyFootballServer pServer) {
+		if (afterCommitCallback != null) {
+			afterCommitCallback.run();
+		}
+	}
+
+	@Override
+	public void doAfterRollback(FantasyFootballServer pServer) {
+		if (afterRollbackCallback != null) {
+			afterRollbackCallback.run();
+		}
 	}
 
 	public IDbUpdateParameter[] getParameters() {

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/db/IDbUpdateParameter.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/db/IDbUpdateParameter.java
@@ -16,4 +16,10 @@ public interface IDbUpdateParameter {
 
 	public DbUpdateStatement getDbUpdateStatement(FantasyFootballServer pServer);
 
+	default void doAfterCommit(FantasyFootballServer pServer) {
+	}
+
+	default void doAfterRollback(FantasyFootballServer pServer) {
+	}
+
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/db/delete/DefaultDbUpdateParameter.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/db/delete/DefaultDbUpdateParameter.java
@@ -21,12 +21,4 @@ public abstract class DefaultDbUpdateParameter implements IDbUpdateParameter {
 		return fUpdatedRows;
 	}
 
-	public void doAfterCommit(FantasyFootballServer pServer) {
-		// implemented in subclasses if necessary
-	}
-
-	public void doAfterRollback(FantasyFootballServer pServer) {
-		// implemented in subclasses if necessary
-	}
-
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/util/UtilServerSetup.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/util/UtilServerSetup.java
@@ -29,7 +29,6 @@ public class UtilServerSetup {
 	public static void loadTeamSetup(GameState gameState, String setupName) {
 
 		if (gameState != null) {
-
 			FantasyFootballServer server = gameState.getServer();
 			Game game = gameState.getGame();
 			Team team = game.isHomePlaying() ? game.getTeamHome() : game.getTeamAway();
@@ -44,23 +43,26 @@ public class UtilServerSetup {
 				}
 
 			} else {
-				DbTeamSetupsForTeamQuery allSetupNamesQuery = (DbTeamSetupsForTeamQuery) server.getDbQueryFactory()
-					.getStatement(DbStatementId.TEAM_SETUPS_QUERY_ALL_FOR_A_TEAM);
-				String[] setupNames = allSetupNamesQuery.execute(team);
-				Session session = game.isHomePlaying() ? server.getSessionManager().getSessionOfHomeCoach(game.getId())
-					: server.getSessionManager().getSessionOfAwayCoach(game.getId());
-				server.getCommunication().sendTeamSetupList(session, setupNames);
+				replyToClientWithTeamSetups(server, game, team);
 			}
 
 		}
 
 	}
 
+	private static void replyToClientWithTeamSetups(FantasyFootballServer server, Game game, Team team) {
+		DbTeamSetupsForTeamQuery allSetupNamesQuery = (DbTeamSetupsForTeamQuery) server.getDbQueryFactory()
+				.getStatement(DbStatementId.TEAM_SETUPS_QUERY_ALL_FOR_A_TEAM);
+		String[] setupNames = allSetupNamesQuery.execute(team);
+		Session session = game.isHomePlaying() ? server.getSessionManager().getSessionOfHomeCoach(game.getId())
+				: server.getSessionManager().getSessionOfAwayCoach(game.getId());
+		server.getCommunication().sendTeamSetupList(session, setupNames);
+	}
+
 	public static void saveTeamSetup(GameState gameState, String pSetupName, int[] pPlayerNumbers,
 	                                 FieldCoordinate[] pPlayerCoordinates) {
 
 		if ((gameState != null) && StringTool.isProvided(pSetupName)) {
-
 			FantasyFootballServer server = gameState.getServer();
 			Game game = gameState.getGame();
 			Team team = game.isHomePlaying() ? game.getTeamHome() : game.getTeamAway();
@@ -90,26 +92,18 @@ public class UtilServerSetup {
 	public static void deleteTeamSetup(GameState gameState, String pSetupName) {
 
 		if (gameState != null) {
-
 			FantasyFootballServer server = gameState.getServer();
 			Game game = gameState.getGame();
 			Team team = game.isHomePlaying() ? game.getTeamHome() : game.getTeamAway();
 
 			if (StringTool.isProvided(pSetupName)) {
-				DbTransaction dbTransaction = new DbTransaction();
+				DbTransaction dbTransaction = new DbTransaction(() -> {
+					replyToClientWithTeamSetups(server, game, team);
+				});
 				dbTransaction.add(new DbTeamSetupsDeleteParameter(team.getId(), pSetupName));
 				server.getDbUpdater().add(dbTransaction);
 			}
-
-			DbTeamSetupsForTeamQuery allSetupNamesQuery = (DbTeamSetupsForTeamQuery) server.getDbQueryFactory()
-				.getStatement(DbStatementId.TEAM_SETUPS_QUERY_ALL_FOR_A_TEAM);
-			String[] setupNames = allSetupNamesQuery.execute(team);
-			Session session = game.isHomePlaying() ? server.getSessionManager().getSessionOfHomeCoach(game.getId())
-				: server.getSessionManager().getSessionOfAwayCoach(game.getId());
-			server.getCommunication().sendTeamSetupList(session, setupNames);
-
 		}
-
 	}
 
 	public static void setupPlayer(GameState gameState, String pPlayerId, FieldCoordinate pCoordinate) {

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/util/UtilServerSetup.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/util/UtilServerSetup.java
@@ -17,6 +17,7 @@ import com.fumbbl.ffb.server.db.delete.DbTeamSetupsDeleteParameter;
 import com.fumbbl.ffb.server.db.insert.DbTeamSetupsInsertParameter;
 import com.fumbbl.ffb.server.db.query.DbTeamSetupsForTeamQuery;
 import com.fumbbl.ffb.server.db.query.DbTeamSetupsQuery;
+import com.fumbbl.ffb.server.net.ServerCommunication;
 import com.fumbbl.ffb.util.StringTool;
 import com.fumbbl.ffb.util.UtilBox;
 import org.eclipse.jetty.websocket.api.Session;
@@ -43,20 +44,25 @@ public class UtilServerSetup {
 				}
 
 			} else {
-				replyToClientWithTeamSetups(server, game, team);
+				replyToClientWithTeamSetups(
+						server.getCommunication(),
+						(DbTeamSetupsForTeamQuery) server.getDbQueryFactory()
+								.getStatement(DbStatementId.TEAM_SETUPS_QUERY_ALL_FOR_A_TEAM),
+						game.isHomePlaying() ?
+								server.getSessionManager().getSessionOfHomeCoach(game.getId()) :
+								server.getSessionManager().getSessionOfAwayCoach(game.getId()),
+						team);
 			}
 
 		}
 
 	}
 
-	private static void replyToClientWithTeamSetups(FantasyFootballServer server, Game game, Team team) {
-		DbTeamSetupsForTeamQuery allSetupNamesQuery = (DbTeamSetupsForTeamQuery) server.getDbQueryFactory()
-				.getStatement(DbStatementId.TEAM_SETUPS_QUERY_ALL_FOR_A_TEAM);
+	private static void replyToClientWithTeamSetups(ServerCommunication communication,
+	                                                DbTeamSetupsForTeamQuery allSetupNamesQuery,
+	                                                Session session, Team team) {
 		String[] setupNames = allSetupNamesQuery.execute(team);
-		Session session = game.isHomePlaying() ? server.getSessionManager().getSessionOfHomeCoach(game.getId())
-				: server.getSessionManager().getSessionOfAwayCoach(game.getId());
-		server.getCommunication().sendTeamSetupList(session, setupNames);
+		communication.sendTeamSetupList(session, setupNames);
 	}
 
 	public static void saveTeamSetup(GameState gameState, String pSetupName, int[] pPlayerNumbers,
@@ -90,16 +96,21 @@ public class UtilServerSetup {
 	}
 
 	public static void deleteTeamSetup(GameState gameState, String pSetupName) {
-
 		if (gameState != null) {
 			FantasyFootballServer server = gameState.getServer();
 			Game game = gameState.getGame();
 			Team team = game.isHomePlaying() ? game.getTeamHome() : game.getTeamAway();
 
 			if (StringTool.isProvided(pSetupName)) {
-				DbTransaction dbTransaction = new DbTransaction(() -> {
-					replyToClientWithTeamSetups(server, game, team);
-				});
+				DbTransaction dbTransaction = new DbTransaction(() ->
+						replyToClientWithTeamSetups(
+								server.getCommunication(),
+								(DbTeamSetupsForTeamQuery) server.getDbQueryFactory()
+										.getStatement(DbStatementId.TEAM_SETUPS_QUERY_ALL_FOR_A_TEAM),
+								game.isHomePlaying() ?
+										server.getSessionManager().getSessionOfHomeCoach(game.getId()) :
+										server.getSessionManager().getSessionOfAwayCoach(game.getId()),
+								team));
 				dbTransaction.add(new DbTeamSetupsDeleteParameter(team.getId(), pSetupName));
 				server.getDbUpdater().add(dbTransaction);
 			}


### PR DESCRIPTION
When client openes teamsetup dialog - that dialog contains "delete" button that allows to remove team set up in the list. Since on server side inside of
com.fumbbl.ffb.server.util.UtilServerSetup#deleteTeamSetup method we add transaction to remove the team asynchronuosly to the queue and then right after that we query database to get the list of team's set up - there is a high chance (and I observed this behavior) for server to first get list of team set ups BEFORE it was deleted (as a result of polling from the queue) and return list of set ups with already deleted items. This change fixes this issue.