### PR TITLE
Expand Dwarfen Grit to all armour rolls

### DIFF
--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/AbstractInjuryTypeBombWithModifier.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/AbstractInjuryTypeBombWithModifier.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.SpecialEffect;
 import com.fumbbl.ffb.factory.ArmorModifierFactory;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
@@ -16,54 +14,57 @@ import com.fumbbl.ffb.modifiers.SpecialEffectArmourModifier;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 
 import java.util.Arrays;
 
-public abstract class AbstractInjuryTypeBombWithModifier<T extends InjuryType> extends InjuryTypeServer<T> {
+public abstract class AbstractInjuryTypeBombWithModifier<T extends InjuryType> extends ModificationAwareInjuryTypeServer<T> {
 
 	AbstractInjuryTypeBombWithModifier(T injuryType) {
 		super(injuryType);
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-	                         ApothecaryMode pApothecaryMode) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		// in BB2020/2025 bombs place players prone, chainsaw only takes effect on falling down or being knocked down
 		// hence chainsaw is ignored here
 
 		boolean skipArmourRoll = pDefender.hasSkillProperty(NamedProperties.placedProneCausesInjuryRoll);
 
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
 		if (skipArmourRoll) {
 			injuryContext.setArmorBroken(true);
 		} else {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 		}
 
 		if (!injuryContext.isArmorBroken()) {
 			((ArmorModifierFactory) game.getFactory(FactoryType.Factory.ARMOUR_MODIFIER)).specialEffectArmourModifiers(SpecialEffect.BOMB, pDefender)
 				.forEach(injuryContext::addArmorModifier);
-				injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
+			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
+		}
+	}
+
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
+
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
+		factory.findInjuryModifiers(game, injuryContext, injuryType.isCausedByOpponent() ? pAttacker : null,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryContext::addInjuryModifier);
+
+		if (Arrays.stream(injuryContext.getArmorModifiers())
+			.noneMatch(modifier -> modifier instanceof SpecialEffectArmourModifier)) {
+			factory.specialEffectInjuryModifiers(SpecialEffect.BOMB)
+				.forEach(injuryContext::addInjuryModifier);
 		}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
-			factory.findInjuryModifiers(game, injuryContext, injuryType.isCausedByOpponent() ? pAttacker : null, pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryContext::addInjuryModifier);
-
-			if (Arrays.stream(injuryContext.getArmorModifiers())
-				.noneMatch(modifier -> modifier instanceof SpecialEffectArmourModifier)) {
-				factory.specialEffectInjuryModifiers(SpecialEffect.BOMB)
-					.forEach(injuryContext::addInjuryModifier);
-			}
-			setInjury(pDefender, gameState, diceRoller);
-
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
-		}
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlock.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlock.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.ArmorModifierFactory;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.Block;
@@ -42,7 +43,7 @@ public class InjuryTypeBlock extends ModificationAwareInjuryTypeServer<Block> {
 
 	@Override
 	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
-		Player<?> pDefender, InjuryContext injuryContext) {
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 		factory.getNigglingInjuryModifier(pDefender).ifPresent(injuryContext::addInjuryModifier);
@@ -64,7 +65,8 @@ public class InjuryTypeBlock extends ModificationAwareInjuryTypeServer<Block> {
 
 	@Override
 	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
-		Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 
 			ArmorModifierFactory armorModifierFactory = game.getFactory(FactoryType.Factory.ARMOUR_MODIFIER);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlockProne.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlockProne.java
@@ -1,5 +1,6 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.injury.BlockProne;
 import com.fumbbl.ffb.injury.context.InjuryContext;
 import com.fumbbl.ffb.model.Game;
@@ -18,7 +19,8 @@ public class InjuryTypeBlockProne extends ModificationAwareInjuryTypeServer<Bloc
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 		Skill stunty = pDefender.getSkillWithProperty(NamedProperties.isHurtMoreEasily);
 		if (stunty != null) {
@@ -28,7 +30,9 @@ public class InjuryTypeBlockProne extends ModificationAwareInjuryTypeServer<Bloc
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (roll) {
 			injuryContext.setArmorRoll(diceRoller.rollArmour());
 		}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlockProneForSpp.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlockProneForSpp.java
@@ -1,5 +1,6 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.injury.BlockProneForSpp;
 import com.fumbbl.ffb.injury.context.InjuryContext;
 import com.fumbbl.ffb.model.Game;
@@ -18,7 +19,8 @@ public class InjuryTypeBlockProneForSpp extends ModificationAwareInjuryTypeServe
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 		Skill stunty = pDefender.getSkillWithProperty(NamedProperties.isHurtMoreEasily);
 		if (stunty != null) {
@@ -28,7 +30,9 @@ public class InjuryTypeBlockProneForSpp extends ModificationAwareInjuryTypeServe
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (roll) {
 			injuryContext.setArmorRoll(diceRoller.rollArmour());
 		}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlockStunned.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlockStunned.java
@@ -1,5 +1,6 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.injury.BlockStunned;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -19,7 +20,8 @@ public class InjuryTypeBlockStunned extends ModificationAwareInjuryTypeServer<Bl
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 		Skill stunty = pDefender.getSkillWithProperty(NamedProperties.isHurtMoreEasily);
 		if (stunty != null) {
@@ -29,7 +31,9 @@ public class InjuryTypeBlockStunned extends ModificationAwareInjuryTypeServer<Bl
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		if (roll) {
 			injuryContext.setArmorRoll(diceRoller.rollArmour());

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlockStunnedForSpp.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBlockStunnedForSpp.java
@@ -1,5 +1,6 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.injury.BlockStunnedForSpp;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -19,7 +20,8 @@ public class InjuryTypeBlockStunnedForSpp extends ModificationAwareInjuryTypeSer
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 		Skill stunty = pDefender.getSkillWithProperty(NamedProperties.isHurtMoreEasily);
 		if (stunty != null) {
@@ -29,7 +31,9 @@ public class InjuryTypeBlockStunnedForSpp extends ModificationAwareInjuryTypeSer
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		if (roll) {
 			injuryContext.setArmorRoll(diceRoller.rollArmour());

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBreatheFire.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBreatheFire.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.BreatheFire;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -20,7 +21,8 @@ public class InjuryTypeBreatheFire extends ModificationAwareInjuryTypeServer<Bre
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
@@ -32,7 +34,9 @@ public class InjuryTypeBreatheFire extends ModificationAwareInjuryTypeServer<Bre
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 			if (roll) {
 				injuryContext.setArmorRoll(diceRoller.rollArmour());

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBreatheFireForSpp.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeBreatheFireForSpp.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.BreatheFireForSpp;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -20,7 +21,8 @@ public class InjuryTypeBreatheFireForSpp extends ModificationAwareInjuryTypeServ
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
@@ -32,7 +34,9 @@ public class InjuryTypeBreatheFireForSpp extends ModificationAwareInjuryTypeServ
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 			if (roll) {
 				injuryContext.setArmorRoll(diceRoller.rollArmour());

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeChainsaw.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeChainsaw.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.factory.SkillFactory;
 import com.fumbbl.ffb.injury.Chainsaw;
@@ -23,7 +24,8 @@ public class InjuryTypeChainsaw extends ModificationAwareInjuryTypeServer<Chains
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
 		factory.findInjuryModifiers(game, injuryContext, pAttacker,
@@ -33,7 +35,9 @@ public class InjuryTypeChainsaw extends ModificationAwareInjuryTypeServer<Chains
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 			if (roll) {
 				injuryContext.setArmorRoll(diceRoller.rollArmour());

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeChainsawForSpp.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeChainsawForSpp.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.factory.SkillFactory;
 import com.fumbbl.ffb.injury.ChainsawForSpp;
@@ -23,7 +24,8 @@ public class InjuryTypeChainsawForSpp extends ModificationAwareInjuryTypeServer<
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
 		factory.findInjuryModifiers(game, injuryContext, pAttacker,
@@ -33,7 +35,9 @@ public class InjuryTypeChainsawForSpp extends ModificationAwareInjuryTypeServer<
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 			if (roll) {
 				injuryContext.setArmorRoll(diceRoller.rollArmour());

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropDodge.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropDodge.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.DropDodge;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -14,7 +12,6 @@ import com.fumbbl.ffb.model.skill.Skill;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 import com.fumbbl.ffb.util.UtilCards;
 import com.fumbbl.ffb.util.UtilPlayer;
 
@@ -24,7 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class InjuryTypeDropDodge extends InjuryTypeServer<DropDodge> {
+public class InjuryTypeDropDodge extends ModificationAwareInjuryTypeServer<DropDodge> {
 	private final Player<?> divingTackler;
 	private final boolean useArmBarModifiers;
 
@@ -47,15 +44,14 @@ public class InjuryTypeDropDodge extends InjuryTypeServer<DropDodge> {
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate,
-	                         FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-	                         ApothecaryMode pApothecaryMode) {
-
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			if (UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
 				injuryContext.addArmorModifiers(pDefender.getSkillWithProperty(NamedProperties.ignoresArmourModifiersFromSkills).getArmorModifiers());
 			} else {
@@ -68,48 +64,66 @@ public class InjuryTypeDropDodge extends InjuryTypeServer<DropDodge> {
 		Skill avOrInjModifierSkill = null;
 
 		if (useArmBarModifiers && fromCoordinate != null) {
-			Set<Player<?>> players = Arrays.stream(UtilPlayer.findAdjacentPlayersWithTacklezones(game, game.getOtherTeam(pDefender.getTeam()), fromCoordinate, false))
-				.collect(Collectors.toSet());
-
-			Player<?> shadowingOrDtPlayer = game.getFieldModel().getPlayer(fromCoordinate);
-
-			if (shadowingOrDtPlayer != null) {
-				players.add(shadowingOrDtPlayer);
-			}
-
-			if (!UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
-				avOrInjModifierSkill = players.stream().filter(player -> game.getFieldModel().getPlayerState(player).hasTacklezones())
-					.map(player -> player.getSkillWithProperty(NamedProperties.affectsEitherArmourOrInjuryOnDodge))
-					.filter(Objects::nonNull).findFirst().orElseGet(() -> {
-
-						if (divingTackler != null && game.getFieldModel().getPlayerCoordinate(divingTackler).equals(fromCoordinate)) {
-							return divingTackler.getSkillWithProperty(NamedProperties.affectsEitherArmourOrInjuryOnDodge);
-						}
-
-						return null;
-					});
-			}
+			avOrInjModifierSkill = avOrInjModifierSkill(game, pDefender, fromCoordinate);
 		}
 
 		if (!injuryContext.isArmorBroken() && avOrInjModifierSkill != null) {
 			avOrInjModifierSkill.getArmorModifiers().forEach(injuryContext::addArmorModifier);
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
+		}
+	}
+
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
+
+		Skill avOrInjModifierSkill = null;
+
+		if (useArmBarModifiers && fromCoordinate != null) {
+			avOrInjModifierSkill = avOrInjModifierSkill(game, pDefender, fromCoordinate);
+		}
+
+		if (avOrInjModifierSkill != null
+			&& avOrInjModifierSkill.getArmorModifiers().stream().anyMatch(injuryContext::hasArmorModifier)) {
 			avOrInjModifierSkill = null;
 		}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
-			factory.findInjuryModifiers(game, injuryContext, pAttacker,
-				pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
-			if (avOrInjModifierSkill != null) {
-				avOrInjModifierSkill.getInjuryModifiers().forEach(injuryContext::addInjuryModifier);
-			}
-
-			setInjury(pDefender, gameState, diceRoller);
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
+		factory.findInjuryModifiers(game, injuryContext, pAttacker,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
+		if (avOrInjModifierSkill != null) {
+			avOrInjModifierSkill.getInjuryModifiers().forEach(injuryContext::addInjuryModifier);
 		}
 
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
+
+	private Skill avOrInjModifierSkill(Game game, Player<?> pDefender, FieldCoordinate fromCoordinate) {
+		Set<Player<?>> players = Arrays.stream(UtilPlayer.findAdjacentPlayersWithTacklezones(game, game.getOtherTeam(pDefender.getTeam()), fromCoordinate, false))
+			.collect(Collectors.toSet());
+
+		Player<?> shadowingOrDtPlayer = game.getFieldModel().getPlayer(fromCoordinate);
+
+		if (shadowingOrDtPlayer != null) {
+			players.add(shadowingOrDtPlayer);
+		}
+
+		if (!UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
+			return players.stream().filter(player -> game.getFieldModel().getPlayerState(player).hasTacklezones())
+				.map(player -> player.getSkillWithProperty(NamedProperties.affectsEitherArmourOrInjuryOnDodge))
+				.filter(Objects::nonNull).findFirst().orElseGet(() -> {
+
+					if (divingTackler != null && game.getFieldModel().getPlayerCoordinate(divingTackler).equals(fromCoordinate)) {
+						return divingTackler.getSkillWithProperty(NamedProperties.affectsEitherArmourOrInjuryOnDodge);
+					}
+
+					return null;
+				});
+		}
+
+		return null;
+	}
+
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropDodgeForSpp.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropDodgeForSpp.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.DropDodgeForSpp;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -14,12 +12,11 @@ import com.fumbbl.ffb.model.skill.Skill;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 import com.fumbbl.ffb.util.UtilCards;
 import java.util.Optional;
 
 
-public class InjuryTypeDropDodgeForSpp extends InjuryTypeServer<DropDodgeForSpp> {
+public class InjuryTypeDropDodgeForSpp extends ModificationAwareInjuryTypeServer<DropDodgeForSpp> {
 
 	private final Player<?> armBarPlayer;
 
@@ -29,16 +26,16 @@ public class InjuryTypeDropDodgeForSpp extends InjuryTypeServer<DropDodgeForSpp>
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate,
-	                         FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-	                         ApothecaryMode pApothecaryMode) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		injuryContext.setAttackerId(armBarPlayer.getId());
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
 
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			if (UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
 				injuryContext.addArmorModifiers(pDefender.getSkillWithProperty(NamedProperties.ignoresArmourModifiersFromSkills).getArmorModifiers());
 			} else {
@@ -48,30 +45,44 @@ public class InjuryTypeDropDodgeForSpp extends InjuryTypeServer<DropDodgeForSpp>
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 		}
 
-		Skill avOrInjModifierSkill = null;
-		if (!UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
-			avOrInjModifierSkill = armBarPlayer.getSkillWithProperty(NamedProperties.affectsEitherArmourOrInjuryOnDodge);
-		}
+		Skill avOrInjModifierSkill = avOrInjModifierSkill(pDefender);
 
 		if (!injuryContext.isArmorBroken() && avOrInjModifierSkill != null) {
 			avOrInjModifierSkill.getArmorModifiers().forEach(injuryContext::addArmorModifier);
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
+		}
+	}
+
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
+
+		injuryContext.setAttackerId(armBarPlayer.getId());
+
+		Skill avOrInjModifierSkill = avOrInjModifierSkill(pDefender);
+
+		if (avOrInjModifierSkill != null
+			&& avOrInjModifierSkill.getArmorModifiers().stream().anyMatch(injuryContext::hasArmorModifier)) {
 			avOrInjModifierSkill = null;
 		}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
-			factory.findInjuryModifiers(game, injuryContext, pAttacker,
-				pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
-			if (avOrInjModifierSkill != null) {
-				avOrInjModifierSkill.getInjuryModifiers().forEach(injuryContext::addInjuryModifier);
-			}
-
-			setInjury(pDefender, gameState, diceRoller);
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
+		factory.findInjuryModifiers(game, injuryContext, pAttacker,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
+		if (avOrInjModifierSkill != null) {
+			avOrInjModifierSkill.getInjuryModifiers().forEach(injuryContext::addInjuryModifier);
 		}
 
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
+	}
+
+	private Skill avOrInjModifierSkill(Player<?> pDefender) {
+		if (!UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
+			return armBarPlayer.getSkillWithProperty(NamedProperties.affectsEitherArmourOrInjuryOnDodge);
+		}
+
+		return null;
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropGFI.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropGFI.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.DropGFI;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -13,26 +11,25 @@ import com.fumbbl.ffb.model.property.NamedProperties;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 import com.fumbbl.ffb.util.UtilCards;
 
 import java.util.Optional;
 
-public class InjuryTypeDropGFI extends InjuryTypeServer<DropGFI> {
+public class InjuryTypeDropGFI extends ModificationAwareInjuryTypeServer<DropGFI> {
 
 	public InjuryTypeDropGFI() {
 		super(new DropGFI());
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-	                         ApothecaryMode pApothecaryMode) {
-
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			if (UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
 				injuryContext.addArmorModifiers(pDefender.getSkillWithProperty(NamedProperties.ignoresArmourModifiersFromSkills).getArmorModifiers());
 			} else {
@@ -41,17 +38,18 @@ public class InjuryTypeDropGFI extends InjuryTypeServer<DropGFI> {
 			}
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 		}
+	}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
-			factory.findInjuryModifiers(game, injuryContext, pAttacker,
-				pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
 
-			setInjury(pDefender, gameState, diceRoller);
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
-		}
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
+		factory.findInjuryModifiers(game, injuryContext, pAttacker,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
 
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropJump.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropJump.java
@@ -111,4 +111,3 @@ public class InjuryTypeDropJump extends ModificationAwareInjuryTypeServer<DropJu
 		return null;
 	}
 }
-

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropJump.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeDropJump.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.DropJump;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -14,7 +12,6 @@ import com.fumbbl.ffb.model.skill.Skill;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 import com.fumbbl.ffb.util.UtilCards;
 import com.fumbbl.ffb.util.UtilPlayer;
 
@@ -24,7 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class InjuryTypeDropJump extends InjuryTypeServer<DropJump> {
+public class InjuryTypeDropJump extends ModificationAwareInjuryTypeServer<DropJump> {
 
 	private final Player<?> divingTackler;
 
@@ -37,16 +34,15 @@ public class InjuryTypeDropJump extends InjuryTypeServer<DropJump> {
 		this.divingTackler = divingTackler;
 	}
 
-
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-													 Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate vacatedFromCoordinate, InjuryContext pOldInjuryContext,
-													 ApothecaryMode pApothecaryMode) {
-
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate vacatedFromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			if (UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
 				injuryContext.addArmorModifiers(pDefender.getSkillWithProperty(NamedProperties.ignoresArmourModifiersFromSkills).getArmorModifiers());
 			} else {
@@ -56,8 +52,37 @@ public class InjuryTypeDropJump extends InjuryTypeServer<DropJump> {
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 		}
 
-		Skill avOrInjModifierSkill = null;
+		Skill avOrInjModifierSkill = avOrInjModifierSkill(game, pDefender, vacatedFromCoordinate);
 
+		if (!injuryContext.isArmorBroken() && avOrInjModifierSkill != null) {
+			avOrInjModifierSkill.getArmorModifiers().forEach(injuryContext::addArmorModifier);
+			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
+		}
+	}
+
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate vacatedFromCoordinate,
+		InjuryContext injuryContext) {
+
+		Skill avOrInjModifierSkill = avOrInjModifierSkill(game, pDefender, vacatedFromCoordinate);
+
+		if (avOrInjModifierSkill != null
+			&& avOrInjModifierSkill.getArmorModifiers().stream().anyMatch(injuryContext::hasArmorModifier)) {
+			avOrInjModifierSkill = null;
+		}
+
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
+		factory.findInjuryModifiers(game, injuryContext, pAttacker,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
+		if (avOrInjModifierSkill != null) {
+			avOrInjModifierSkill.getInjuryModifiers().forEach(injuryContext::addInjuryModifier);
+		}
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
+	}
+
+	private Skill avOrInjModifierSkill(Game game, Player<?> pDefender, FieldCoordinate vacatedFromCoordinate) {
 		FieldCoordinate fromCoordiante = vacatedFromCoordinate == null ? game.getFieldModel().getPlayerCoordinate(pDefender) : vacatedFromCoordinate;
 
 		Set<Player<?>> players = Arrays.stream(UtilPlayer.findAdjacentPlayersWithTacklezones(game, game.getOtherTeam(pDefender.getTeam()), fromCoordiante, false))
@@ -72,7 +97,7 @@ public class InjuryTypeDropJump extends InjuryTypeServer<DropJump> {
 		}
 
 		if (!UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
-			avOrInjModifierSkill = players.stream().map(player -> player.getSkillWithProperty(NamedProperties.affectsEitherArmourOrInjuryOnJump))
+			return players.stream().map(player -> player.getSkillWithProperty(NamedProperties.affectsEitherArmourOrInjuryOnJump))
 				.filter(Objects::nonNull).findFirst().orElseGet(() -> {
 
 					if (divingTackler != null) {
@@ -83,25 +108,7 @@ public class InjuryTypeDropJump extends InjuryTypeServer<DropJump> {
 				});
 		}
 
-		if (!injuryContext.isArmorBroken() && avOrInjModifierSkill != null) {
-			avOrInjModifierSkill.getArmorModifiers().forEach(injuryContext::addArmorModifier);
-			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
-			avOrInjModifierSkill = null;
-		}
-
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
-			factory.findInjuryModifiers(game, injuryContext, pAttacker,
-				pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
-			if (avOrInjModifierSkill != null) {
-				avOrInjModifierSkill.getInjuryModifiers().forEach(injuryContext::addInjuryModifier);
-			}
-			setInjury(pDefender, gameState, diceRoller);
-
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
-		}
-
+		return null;
 	}
 }
+

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeFireball.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeFireball.java
@@ -58,4 +58,3 @@ public class InjuryTypeFireball extends ModificationAwareInjuryTypeServer<Fireba
 		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 }
-

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeFireball.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeFireball.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.SpecialEffect;
 import com.fumbbl.ffb.factory.ArmorModifierFactory;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
@@ -15,23 +13,23 @@ import com.fumbbl.ffb.modifiers.SpecialEffectArmourModifier;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 
 import java.util.Arrays;
 
-public class InjuryTypeFireball extends InjuryTypeServer<Fireball> {
+public class InjuryTypeFireball extends ModificationAwareInjuryTypeServer<Fireball> {
 	public InjuryTypeFireball() {
 		super(new Fireball());
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-	                         ApothecaryMode pApothecaryMode) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 			if (!injuryContext.isArmorBroken()) {
 				((ArmorModifierFactory) game.getFactory(FactoryType.Factory.ARMOUR_MODIFIER)).specialEffectArmourModifiers(SpecialEffect.FIREBALL, pDefender)
@@ -39,24 +37,25 @@ public class InjuryTypeFireball extends InjuryTypeServer<Fireball> {
 				injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 			}
 		}
+	}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
 
-			((InjuryModifierFactory) game.getFactory(FactoryType.Factory.INJURY_MODIFIER)).findInjuryModifiers(game, injuryContext, pAttacker,
-				pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
+		((InjuryModifierFactory) game.getFactory(FactoryType.Factory.INJURY_MODIFIER)).findInjuryModifiers(game, injuryContext, pAttacker,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
 
-			if (Arrays.stream(injuryContext.getArmorModifiers())
-				.noneMatch(modifier -> modifier instanceof SpecialEffectArmourModifier)) {
-				((InjuryModifierFactory) game.getFactory(FactoryType.Factory.INJURY_MODIFIER)).specialEffectInjuryModifiers(SpecialEffect.FIREBALL)
-					.forEach(injuryContext::addInjuryModifier);
-			}
-			setInjury(pDefender, gameState, diceRoller);
-
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
+		if (Arrays.stream(injuryContext.getArmorModifiers())
+			.noneMatch(modifier -> modifier instanceof SpecialEffectArmourModifier)) {
+			((InjuryModifierFactory) game.getFactory(FactoryType.Factory.INJURY_MODIFIER)).specialEffectInjuryModifiers(SpecialEffect.FIREBALL)
+				.forEach(injuryContext::addInjuryModifier);
 		}
 
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 }
+

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeFoul.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeFoul.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.ArmorModifierFactory;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.Foul;
@@ -31,7 +32,8 @@ public class InjuryTypeFoul extends ModificationAwareInjuryTypeServer<Foul> {
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
@@ -43,8 +45,9 @@ public class InjuryTypeFoul extends ModificationAwareInjuryTypeServer<Foul> {
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender,
-														DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		// Blatant Foul breaks armor without roll
 		if (game.isActive(NamedProperties.foulBreaksArmourWithoutRoll)) {
 			injuryContext.setArmorBroken(true);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeFoulForSpp.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeFoulForSpp.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.ArmorModifierFactory;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.FoulForSpp;
@@ -31,7 +32,8 @@ public class InjuryTypeFoulForSpp extends ModificationAwareInjuryTypeServer<Foul
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
@@ -43,8 +45,9 @@ public class InjuryTypeFoulForSpp extends ModificationAwareInjuryTypeServer<Foul
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender,
-														DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		// Blatant Foul breaks armor without roll
 		if (game.isActive(NamedProperties.foulBreaksArmourWithoutRoll)) {
 			injuryContext.setArmorBroken(true);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeKegHit.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeKegHit.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.KegHit;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -13,25 +11,24 @@ import com.fumbbl.ffb.model.property.NamedProperties;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 import com.fumbbl.ffb.util.UtilCards;
 
 import java.util.Optional;
 
-public class InjuryTypeKegHit extends InjuryTypeServer<KegHit> {
+public class InjuryTypeKegHit extends ModificationAwareInjuryTypeServer<KegHit> {
 	public InjuryTypeKegHit() {
 		super(new KegHit());
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-													 Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-													 ApothecaryMode pApothecaryMode) {
-
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			if (UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
 				injuryContext.addArmorModifiers(pDefender.getSkillWithProperty(NamedProperties.ignoresArmourModifiersFromSkills).getArmorModifiers());
 			} else {
@@ -40,17 +37,18 @@ public class InjuryTypeKegHit extends InjuryTypeServer<KegHit> {
 			}
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 		}
+	}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
-			factory.findInjuryModifiers(game, injuryContext, null,
-				pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
 
-			setInjury(pDefender, gameState, diceRoller);
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
+		factory.findInjuryModifiers(game, injuryContext, null,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
 
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
-		}
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeProjectileVomit.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeProjectileVomit.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.ProjectileVomit;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -21,7 +22,8 @@ public class InjuryTypeProjectileVomit extends ModificationAwareInjuryTypeServer
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
@@ -33,7 +35,9 @@ public class InjuryTypeProjectileVomit extends ModificationAwareInjuryTypeServer
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 			if (roll) {
 				injuryContext.setArmorRoll(diceRoller.rollArmour());

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeQuickBite.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeQuickBite.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.QuickBite;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -21,7 +22,8 @@ public class InjuryTypeQuickBite extends ModificationAwareInjuryTypeServer<Quick
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
@@ -33,7 +35,9 @@ public class InjuryTypeQuickBite extends ModificationAwareInjuryTypeServer<Quick
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 			if (roll) {
 				injuryContext.setArmorRoll(diceRoller.rollArmour());

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeSabotaged.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeSabotaged.java
@@ -1,8 +1,6 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.injury.Sabotaged;
 import com.fumbbl.ffb.injury.context.InjuryContext;
 import com.fumbbl.ffb.model.Game;
@@ -10,29 +8,32 @@ import com.fumbbl.ffb.model.Player;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 
-public class InjuryTypeSabotaged extends InjuryTypeServer<Sabotaged> {
+public class InjuryTypeSabotaged extends ModificationAwareInjuryTypeServer<Sabotaged> {
 
 	public InjuryTypeSabotaged() {
 		super(new Sabotaged());
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> attacker, Player<?> defender, FieldCoordinate defenderCoordinate,
-	                         FieldCoordinate fromCoordinate, InjuryContext oldContext, ApothecaryMode apothecaryMode) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> attacker,
+		Player<?> defender, FieldCoordinate defenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		// standard armour + injury roll, but no block modifiers
-		injuryContext.setArmorRoll(diceRoller.rollArmour());
-		injuryContext.setArmorBroken(DiceInterpreter.getInstance().isArmourBroken(gameState, injuryContext));
-
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			// no extra modifiers
-			setInjury(defender, gameState, diceRoller, injuryContext);
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
+		if (roll) {
+			injuryContext.setArmorRoll(diceRoller.rollArmour());
 		}
+		injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
+	}
+
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> attacker,
+		Player<?> defender, FieldCoordinate defenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
+
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		// no extra modifiers
+		setInjury(defender, gameState, diceRoller, injuryContext);
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeStab.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeStab.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.ArmorModifierFactory;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.Stab;
@@ -35,7 +36,8 @@ public class InjuryTypeStab extends ModificationAwareInjuryTypeServer<Stab> {
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
 		if (useInjuryModifiers) {
@@ -48,7 +50,9 @@ public class InjuryTypeStab extends ModificationAwareInjuryTypeServer<Stab> {
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 
 			ArmorModifierFactory armorModifierFactory = game.getFactory(FactoryType.Factory.ARMOUR_MODIFIER);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeStabForSpp.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeStabForSpp.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.ArmorModifierFactory;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.StabForSpp;
@@ -35,7 +36,8 @@ public class InjuryTypeStabForSpp extends ModificationAwareInjuryTypeServer<Stab
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
 		if (useInjuryModifiers) {
@@ -48,7 +50,9 @@ public class InjuryTypeStabForSpp extends ModificationAwareInjuryTypeServer<Stab
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 
 			ArmorModifierFactory armorModifierFactory = game.getFactory(FactoryType.Factory.ARMOUR_MODIFIER);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeTTMHitPlayer.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeTTMHitPlayer.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.TTMHitPlayer;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -13,24 +11,24 @@ import com.fumbbl.ffb.model.property.NamedProperties;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 import com.fumbbl.ffb.util.UtilCards;
 
 import java.util.Optional;
 
-public class InjuryTypeTTMHitPlayer extends InjuryTypeServer<TTMHitPlayer> {
+public class InjuryTypeTTMHitPlayer extends ModificationAwareInjuryTypeServer<TTMHitPlayer> {
 	public InjuryTypeTTMHitPlayer() {
 		super(new TTMHitPlayer());
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-	                         ApothecaryMode pApothecaryMode) {
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			if (UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
 				injuryContext.addArmorModifiers(pDefender.getSkillWithProperty(NamedProperties.ignoresArmourModifiersFromSkills).getArmorModifiers());
 			} else {
@@ -39,17 +37,18 @@ public class InjuryTypeTTMHitPlayer extends InjuryTypeServer<TTMHitPlayer> {
 			}
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 		}
+	}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
-			factory.findInjuryModifiers(game, injuryContext, pAttacker,
-				pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
 
-			setInjury(pDefender, gameState, diceRoller);
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
+		factory.findInjuryModifiers(game, injuryContext, pAttacker,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
 
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
-		}
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeTTMHitPlayerForSpp.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeTTMHitPlayerForSpp.java
@@ -1,8 +1,6 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.injury.TTMHitPlayerForSpp;
 import com.fumbbl.ffb.injury.context.InjuryContext;
 import com.fumbbl.ffb.model.Game;
@@ -14,26 +12,26 @@ import com.fumbbl.ffb.modifiers.InjuryModifierContext;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 import com.fumbbl.ffb.util.UtilCards;
 
 import java.util.Optional;
 
-public class InjuryTypeTTMHitPlayerForSpp extends InjuryTypeServer<TTMHitPlayerForSpp> {
+public class InjuryTypeTTMHitPlayerForSpp extends ModificationAwareInjuryTypeServer<TTMHitPlayerForSpp> {
 	public InjuryTypeTTMHitPlayerForSpp() {
 		super(new TTMHitPlayerForSpp());
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-	                         ApothecaryMode pApothecaryMode) {
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		Optional<Skill> lethalFlight = UtilCards.getSkillWithProperty(pAttacker, NamedProperties.affectsEitherArmourOrInjuryOnTtm);
 
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			if (UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
 				injuryContext.addArmorModifiers(pDefender.getSkillWithProperty(NamedProperties.ignoresArmourModifiersFromSkills).getArmorModifiers());
 			} else {
@@ -42,27 +40,34 @@ public class InjuryTypeTTMHitPlayerForSpp extends InjuryTypeServer<TTMHitPlayerF
 			}
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 
-			if (!injuryContext.isArmorBroken() && lethalFlight.isPresent() 
-					&& !UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
+			if (!injuryContext.isArmorBroken() && lethalFlight.isPresent()
+				&& !UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
 				lethalFlight.get().getArmorModifiers().stream()
 					.filter(mod -> mod.appliesToContext(new ArmorModifierContext(game, pAttacker, pDefender, false, false, 0, true)))
 					.forEach(injuryContext::addArmorModifier);
 				injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
-				lethalFlight = Optional.empty(); // consumed on armour
 			}
 		}
+	}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
 
-			lethalFlight.ifPresent(skill -> skill.getInjuryModifiers().stream()
-				.filter(mod -> mod.appliesToContext(new InjuryModifierContext(game, injuryContext, pAttacker, pDefender, false, false, false, false, true)))
-				.forEach(injuryContext::addInjuryModifier));
+		Optional<Skill> lethalFlight = UtilCards.getSkillWithProperty(pAttacker, NamedProperties.affectsEitherArmourOrInjuryOnTtm);
 
-			setInjury(pDefender, gameState, diceRoller);
-
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
+		if (lethalFlight.isPresent()
+			&& lethalFlight.get().getArmorModifiers().stream().anyMatch(injuryContext::hasArmorModifier)) {
+			lethalFlight = Optional.empty();
 		}
+
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+
+		lethalFlight.ifPresent(skill -> skill.getInjuryModifiers().stream()
+			.filter(mod -> mod.appliesToContext(new InjuryModifierContext(game, injuryContext, pAttacker, pDefender, false, false, false, false, true)))
+			.forEach(injuryContext::addInjuryModifier));
+
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeTTMLanding.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeTTMLanding.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.TTMLanding;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -13,25 +11,24 @@ import com.fumbbl.ffb.model.property.NamedProperties;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 import com.fumbbl.ffb.util.UtilCards;
 
 import java.util.Optional;
 
-public class InjuryTypeTTMLanding extends InjuryTypeServer<TTMLanding> {
+public class InjuryTypeTTMLanding extends ModificationAwareInjuryTypeServer<TTMLanding> {
 	public InjuryTypeTTMLanding() {
 		super(new TTMLanding());
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-	                         ApothecaryMode pApothecaryMode) {
-
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			if (UtilCards.hasUnusedSkillWithProperty(pDefender, NamedProperties.ignoresArmourModifiersFromSkills)) {
 				injuryContext.addArmorModifiers(pDefender.getSkillWithProperty(NamedProperties.ignoresArmourModifiersFromSkills).getArmorModifiers());
 			} else {
@@ -40,17 +37,18 @@ public class InjuryTypeTTMLanding extends InjuryTypeServer<TTMLanding> {
 			}
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 		}
+	}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
-			factory.findInjuryModifiers(game, injuryContext, null,
-				pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
 
-			setInjury(pDefender, gameState, diceRoller);
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
+		factory.findInjuryModifiers(game, injuryContext, null,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
 
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
-		}
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeThenIStartedBlastin.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeThenIStartedBlastin.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
 import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.ThenIStartedBlastin;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -21,7 +22,8 @@ public class InjuryTypeThenIStartedBlastin extends ModificationAwareInjuryTypeSe
 	}
 
 	@Override
-	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext) {
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext) {
 		injuryContext.setInjuryRoll(diceRoller.rollInjury());
 
 		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
@@ -33,7 +35,9 @@ public class InjuryTypeThenIStartedBlastin extends ModificationAwareInjuryTypeSe
 	}
 
 	@Override
-	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 		if (!injuryContext.isArmorBroken()) {
 			if (roll) {
 				injuryContext.setArmorRoll(diceRoller.rollArmour());

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeThrowARockStalling.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/InjuryTypeThrowARockStalling.java
@@ -1,9 +1,7 @@
 package com.fumbbl.ffb.server.injury.injuryType;
 
-import com.fumbbl.ffb.ApothecaryMode;
 import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.factory.InjuryModifierFactory;
 import com.fumbbl.ffb.injury.ThrowARock;
 import com.fumbbl.ffb.injury.context.InjuryContext;
@@ -12,36 +10,35 @@ import com.fumbbl.ffb.model.Player;
 import com.fumbbl.ffb.server.DiceInterpreter;
 import com.fumbbl.ffb.server.DiceRoller;
 import com.fumbbl.ffb.server.GameState;
-import com.fumbbl.ffb.server.step.IStep;
 
-public class InjuryTypeThrowARockStalling extends InjuryTypeServer<ThrowARock> {
+public class InjuryTypeThrowARockStalling extends ModificationAwareInjuryTypeServer<ThrowARock> {
 	public InjuryTypeThrowARockStalling() {
 		super(new ThrowARock());
 	}
 
 	@Override
-	public void handleInjury(IStep step, Game game, GameState gameState, DiceRoller diceRoller,
-	                         Player<?> pAttacker, Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext pOldInjuryContext,
-	                         ApothecaryMode pApothecaryMode) {
-
-		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
+	protected void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll) {
 
 		if (!injuryContext.isArmorBroken()) {
-			injuryContext.setArmorRoll(diceRoller.rollArmour());
+			if (roll) {
+				injuryContext.setArmorRoll(diceRoller.rollArmour());
+			}
 			injuryContext.setArmorBroken(diceInterpreter.isArmourBroken(gameState, injuryContext));
 		}
+	}
 
-		if (injuryContext.isArmorBroken()) {
-			injuryContext.setInjuryRoll(diceRoller.rollInjury());
-			InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
-			factory.findInjuryModifiers(game, injuryContext, pAttacker,
-				pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
+	@Override
+	protected void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		InjuryContext injuryContext) {
 
-			setInjury(pDefender, gameState, diceRoller);
+		injuryContext.setInjuryRoll(diceRoller.rollInjury());
+		InjuryModifierFactory factory = game.getFactory(FactoryType.Factory.INJURY_MODIFIER);
+		factory.findInjuryModifiers(game, injuryContext, pAttacker,
+			pDefender, isStab(), isFoul(), isVomitLike()).forEach(injuryModifier -> injuryContext.addInjuryModifier(injuryModifier));
 
-		} else {
-			injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
-		}
-
+		setInjury(pDefender, gameState, diceRoller, injuryContext);
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/ModificationAwareInjuryTypeServer.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/injuryType/ModificationAwareInjuryTypeServer.java
@@ -42,7 +42,8 @@ public abstract class ModificationAwareInjuryTypeServer<T extends InjuryType> ex
 
 		DiceInterpreter diceInterpreter = DiceInterpreter.getInstance();
 
-		armourRoll(game, gameState, diceRoller, pAttacker, pDefender, diceInterpreter, injuryContext, true);
+		armourRoll(game, gameState, diceRoller, pAttacker, pDefender, pDefenderCoordinate, fromCoordinate, diceInterpreter,
+			injuryContext, true);
 
 		boolean modified = false;
 
@@ -65,20 +66,24 @@ public abstract class ModificationAwareInjuryTypeServer<T extends InjuryType> ex
 		if (modified) {
 			ModifiedInjuryContext alternateInjuryContext = injuryContext.getModifiedInjuryContext();
 			alternateInjuryContext.setArmorBroken(false);
-			armourRoll(game, gameState, diceRoller, pAttacker, pDefender, diceInterpreter, alternateInjuryContext, false);
+			armourRoll(game, gameState, diceRoller, pAttacker, pDefender, pDefenderCoordinate, fromCoordinate,
+				diceInterpreter, alternateInjuryContext, false);
 
-			injury(game, gameState, diceRoller, pAttacker, pDefender, Optional.empty(), alternateInjuryContext);
+			injury(game, gameState, diceRoller, pAttacker, pDefender, pDefenderCoordinate, fromCoordinate, Optional.empty(),
+				alternateInjuryContext);
 		}
 
-		injury(game, gameState, diceRoller, pAttacker, pDefender, modification, injuryContext);
+		injury(game, gameState, diceRoller, pAttacker, pDefender, pDefenderCoordinate, fromCoordinate, modification,
+			injuryContext);
 
 	}
 
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	private void injury(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender,
-	                    Optional<IInjuryContextModification> modification, InjuryContext currentInjuryContext) {
+			FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+			Optional<IInjuryContextModification> modification, InjuryContext currentInjuryContext) {
 		if (currentInjuryContext.isArmorBroken()) {
-			injuryRoll(game, gameState, diceRoller, pAttacker, pDefender, currentInjuryContext);
+			injuryRoll(game, gameState, diceRoller, pAttacker, pDefender, pDefenderCoordinate, fromCoordinate, currentInjuryContext);
 
 			if (modification.isPresent()) {
 				boolean modified = ((InjuryContextModification<? extends ModificationParams>) modification.get()).modifyInjury(gameState, currentInjuryContext, injuryType);
@@ -96,7 +101,10 @@ public abstract class ModificationAwareInjuryTypeServer<T extends InjuryType> ex
 		injuryContext.setInjury(new PlayerState(PlayerState.PRONE));
 	}
 
-	protected abstract void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, InjuryContext injuryContext);
+	protected abstract void injuryRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate, InjuryContext injuryContext);
 
-	protected abstract void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker, Player<?> pDefender, DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll);
+	protected abstract void armourRoll(Game game, GameState gameState, DiceRoller diceRoller, Player<?> pAttacker,
+		Player<?> pDefender, FieldCoordinate pDefenderCoordinate, FieldCoordinate fromCoordinate,
+		DiceInterpreter diceInterpreter, InjuryContext injuryContext, boolean roll);
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/InjuryContextModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/InjuryContextModification.java
@@ -24,9 +24,15 @@ public abstract class InjuryContextModification<T extends ModificationParams> im
 
 	private Skill skill;
 	private final Set<Class<? extends InjuryType>> validInjuryTypes;
+	private final boolean validForAllInjuryTypes;
 
 	public InjuryContextModification(Set<Class<? extends InjuryType>> validInjuryTypes) {
+		this(validInjuryTypes, false);
+	}
+
+	public InjuryContextModification(Set<Class<? extends InjuryType>> validInjuryTypes, boolean validForAllInjuryTypes) {
 		this.validInjuryTypes = validInjuryTypes;
+		this.validForAllInjuryTypes = validForAllInjuryTypes;
 	}
 
 	protected abstract T params(GameState gameState, ModifiedInjuryContext newContext, InjuryType injuryType);
@@ -124,7 +130,7 @@ public abstract class InjuryContextModification<T extends ModificationParams> im
 	protected abstract SkillUse skillUse();
 
 	public boolean isValidType(InjuryType injuryType) {
-		return validInjuryTypes.contains(injuryType.getClass());
+		return validForAllInjuryTypes || validInjuryTypes.contains(injuryType.getClass());
 	}
 
 	public Skill getSkill() {

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/DwarfenGritModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/DwarfenGritModification.java
@@ -1,5 +1,7 @@
 package com.fumbbl.ffb.server.injury.modification.bb2025;
 
+import com.fumbbl.ffb.injury.context.InjuryContext;
+import com.fumbbl.ffb.model.Game;
 import com.fumbbl.ffb.server.injury.modification.ModificationParams;
 
 
@@ -17,6 +19,11 @@ public class DwarfenGritModification extends RerollArmourModification {
 
 	@Override
 	public boolean appliesToDefender() {
+		return true;
+	}
+
+	@Override
+	protected boolean allowedForAttackerAndDefenderTeams(Game game, InjuryContext injuryContext) {
 		return true;
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/DwarfenGritModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/DwarfenGritModification.java
@@ -1,21 +1,12 @@
 package com.fumbbl.ffb.server.injury.modification.bb2025;
 
-import com.fumbbl.ffb.injury.Block;
-import com.fumbbl.ffb.injury.DropDodge;
-import com.fumbbl.ffb.injury.DropDodgeForSpp;
-import com.fumbbl.ffb.injury.InjuryType;
 import com.fumbbl.ffb.server.injury.modification.ModificationParams;
 
-import java.util.HashSet;
 
 public class DwarfenGritModification extends RerollArmourModification {
 
 	public DwarfenGritModification() {
-		super(new HashSet<Class<? extends InjuryType>>() {{
-			add(Block.class);
-			add(DropDodge.class);
-			add(DropDodgeForSpp.class);
-		}});
+		super(true); // no injury type restriction
 	}
 
 	@Override

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/DwarfenGritModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/DwarfenGritModification.java
@@ -1,20 +1,27 @@
 package com.fumbbl.ffb.server.injury.modification.bb2025;
 
 import com.fumbbl.ffb.injury.Block;
+import com.fumbbl.ffb.injury.DropDodge;
+import com.fumbbl.ffb.injury.DropDodgeForSpp;
 import com.fumbbl.ffb.injury.InjuryType;
 import com.fumbbl.ffb.server.injury.modification.ModificationParams;
 
-import java.util.Collections;
+import java.util.HashSet;
 
 public class DwarfenGritModification extends RerollArmourModification {
 
 	public DwarfenGritModification() {
-		super(Collections.<Class<? extends InjuryType>>singleton(Block.class));
+		super(new HashSet<Class<? extends InjuryType>>() {{
+			add(Block.class);
+			add(DropDodge.class);
+			add(DropDodgeForSpp.class);
+		}});
 	}
 
 	@Override
 	protected boolean tryArmourRollModification(ModificationParams params) {
-		return params.getNewContext().isArmorBroken();
+		return params.getNewContext().getArmorRoll() != null
+			&& params.getNewContext().isArmorBroken();
 	}
 
 	@Override

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/RerollArmourModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/RerollArmourModification.java
@@ -7,12 +7,17 @@ import com.fumbbl.ffb.server.GameState;
 import com.fumbbl.ffb.server.injury.modification.InjuryContextModification;
 import com.fumbbl.ffb.server.injury.modification.ModificationParams;
 
+import java.util.Collections;
 import java.util.Set;
 
 public abstract class RerollArmourModification extends InjuryContextModification<ModificationParams> {
 
 	protected RerollArmourModification(Set<Class<? extends InjuryType>> validTypes) {
 		super(validTypes);
+	}
+
+	protected RerollArmourModification(boolean validForAllInjuryTypes) {
+		super(Collections.<Class<? extends InjuryType>>emptySet(), validForAllInjuryTypes);
 	}
 
 	@Override

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepFallDown.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepFallDown.java
@@ -14,6 +14,7 @@ import com.fumbbl.ffb.server.GameState;
 import com.fumbbl.ffb.server.IServerJsonOption;
 import com.fumbbl.ffb.server.InjuryResult;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeServer;
+import com.fumbbl.ffb.server.model.DropPlayerContext;
 import com.fumbbl.ffb.server.net.ReceivedCommand;
 import com.fumbbl.ffb.server.step.AbstractStep;
 import com.fumbbl.ffb.server.step.StepAction;
@@ -85,11 +86,11 @@ public class StepFallDown extends AbstractStep {
 		FieldCoordinate playerCoordinate = game.getFieldModel().getPlayerCoordinate(actingPlayer.getPlayer());
 		InjuryResult injuryResultAttacker = UtilServerInjury.handleInjury(this, fInjuryType, null, actingPlayer.getPlayer(),
 			playerCoordinate, fCoordinateFrom, null, ApothecaryMode.ATTACKER);
-		publishParameters(UtilServerInjury.dropPlayer(this, actingPlayer.getPlayer(), ApothecaryMode.ATTACKER, true));
-		publishParameter(new StepParameter(StepParameterKey.INJURY_RESULT, injuryResultAttacker));
-		if (fInjuryType.fallingDownCausesTurnover() && (game.getTurnMode() != TurnMode.PASS_BLOCK)) {
-			publishParameter(new StepParameter(StepParameterKey.END_TURN, true));
-		}
+		boolean endTurn = fInjuryType.fallingDownCausesTurnover() && (game.getTurnMode() != TurnMode.PASS_BLOCK);
+
+		publishParameter(new StepParameter(StepParameterKey.DROP_PLAYER_CONTEXT,
+			new DropPlayerContext(injuryResultAttacker, endTurn, true, null, actingPlayer.getPlayerId(),
+				ApothecaryMode.ATTACKER, false, false, null, endTurn, false, null)));
 		getResult().setNextAction(StepAction.NEXT_STEP);
 	}
 

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StallingExtension.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StallingExtension.java
@@ -15,18 +15,17 @@ import com.fumbbl.ffb.report.mixed.ReportThrowAtStallingPlayer;
 import com.fumbbl.ffb.server.GameState;
 import com.fumbbl.ffb.server.InjuryResult;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeThrowARockStalling;
+import com.fumbbl.ffb.server.model.DropPlayerContext;
 import com.fumbbl.ffb.server.model.SteadyFootingContext;
 import com.fumbbl.ffb.server.step.IStep;
 import com.fumbbl.ffb.server.step.StepParameter;
 import com.fumbbl.ffb.server.step.StepParameterKey;
-import com.fumbbl.ffb.server.step.bb2025.command.DropPlayerCommand;
 import com.fumbbl.ffb.server.util.UtilServerGame;
 import com.fumbbl.ffb.server.util.UtilServerInjury;
 import com.fumbbl.ffb.util.ArrayTool;
 import com.fumbbl.ffb.util.UtilPlayer;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -98,9 +97,10 @@ public class StallingExtension {
 
 			InjuryResult injuryResult = UtilServerInjury.handleInjury(step,
 				new InjuryTypeThrowARockStalling(), null, player, playerCoordinate, null, null, ApothecaryMode.HIT_PLAYER);
+			DropPlayerContext dropPlayerContext = new DropPlayerContext(injuryResult, false, true,
+				null, player.getId(), ApothecaryMode.HIT_PLAYER, false);
 			step.publishParameter(new StepParameter(StepParameterKey.STEADY_FOOTING_CONTEXT,
-				new SteadyFootingContext(injuryResult, Collections.singletonList(new DropPlayerCommand(player.getId(),
-					ApothecaryMode.HIT_PLAYER, true)))));
+				new SteadyFootingContext(dropPlayerContext)));
 		}
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepDropFallingPlayers.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepDropFallingPlayers.java
@@ -210,8 +210,10 @@ public class StepDropFallingPlayers extends AbstractStep {
 				publishParameter(StepParameter.from(StepParameterKey.DROP_PLAYER_CONTEXT,dropPlayerContext));
 				publishParameter(StepParameter.from(StepParameterKey.INJURY_RESULT, injuryResultAttacker));
 			} else {
+				DropPlayerContext dropPlayerContext =
+					new DropPlayerContext(injuryResultAttacker, actingPlayer.getPlayerId(), ApothecaryMode.ATTACKER, true);
 				publishParameter(new StepParameter(StepParameterKey.STEADY_FOOTING_CONTEXT,
-					new SteadyFootingContext(injuryResultAttacker, deferredCommands)));
+					new SteadyFootingContext(dropPlayerContext, deferredCommands)));
 			}
 		}
 		getResult().setNextAction(StepAction.NEXT_STEP);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/special/StepSpecialEffect.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/special/StepSpecialEffect.java
@@ -180,7 +180,8 @@ public final class StepSpecialEffect extends AbstractStep {
 					InjuryResult injuryResult = UtilServerInjury.handleInjury(this,
 						bombardierGetsSpp ? new InjuryTypeBombWithModifierForSpp() : new InjuryTypeBombWithModifier(), 
 						bombardierGetsSpp ? bombardier : null, player, playerCoordinate, null, null, ApothecaryMode.SPECIAL_EFFECT);
-					publishParameter(new StepParameter(StepParameterKey.STEADY_FOOTING_CONTEXT, new SteadyFootingContext(injuryResult, Collections.singletonList(command))));
+					DropPlayerContext dropPlayerContext = new DropPlayerContext(injuryResult, player.getId(), ApothecaryMode.SPECIAL_EFFECT, true);
+					publishParameter(new StepParameter(StepParameterKey.STEADY_FOOTING_CONTEXT, new SteadyFootingContext(dropPlayerContext, Collections.singletonList(command))));
 				}
 
 				// check end turn

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/special/StepSpecialEffect.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/special/StepSpecialEffect.java
@@ -28,6 +28,7 @@ import com.fumbbl.ffb.server.InjuryResult;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeBombWithModifier;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeBombWithModifierForSpp;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeFireball;
+import com.fumbbl.ffb.server.model.DropPlayerContext;
 import com.fumbbl.ffb.server.model.SteadyFootingContext;
 import com.fumbbl.ffb.server.step.AbstractStep;
 import com.fumbbl.ffb.server.step.StepAction;
@@ -37,7 +38,6 @@ import com.fumbbl.ffb.server.step.StepParameter;
 import com.fumbbl.ffb.server.step.StepParameterKey;
 import com.fumbbl.ffb.server.step.StepParameterSet;
 import com.fumbbl.ffb.server.step.bb2025.shared.StepCatchScatterThrowIn;
-import com.fumbbl.ffb.server.step.bb2025.command.DropPlayerCommand;
 import com.fumbbl.ffb.server.step.bb2025.command.DropPlayerFromBombCommand;
 import com.fumbbl.ffb.server.util.UtilServerInjury;
 import com.fumbbl.ffb.util.UtilCards;
@@ -154,10 +154,11 @@ public final class StepSpecialEffect extends AbstractStep {
 					}
 				}
 				if (fSpecialEffect == SpecialEffect.FIREBALL) {
-					DropPlayerCommand dropPlayerCommand = new DropPlayerCommand(player.getId(), ApothecaryMode.SPECIAL_EFFECT, true);
 					InjuryResult injuryResult = UtilServerInjury.handleInjury(this,
 						new InjuryTypeFireball(), null, player, playerCoordinate, null, null, ApothecaryMode.SPECIAL_EFFECT);
-					publishParameter(new StepParameter(StepParameterKey.STEADY_FOOTING_CONTEXT, new SteadyFootingContext(injuryResult, Collections.singletonList(dropPlayerCommand))));
+					DropPlayerContext dropPlayerContext = new DropPlayerContext(injuryResult, false, true,
+						null, player.getId(), ApothecaryMode.SPECIAL_EFFECT, false);
+					publishParameter(new StepParameter(StepParameterKey.STEADY_FOOTING_CONTEXT, new SteadyFootingContext(dropPlayerContext)));
 				}
 				if (fSpecialEffect == SpecialEffect.BOMB) {
 					boolean bombFromHome = game.getTurnMode() == TurnMode.BOMB_HOME || game.getTurnMode() == TurnMode.BOMB_HOME_BLITZ;

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/ttm/StepInitScatterPlayer.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/ttm/StepInitScatterPlayer.java
@@ -29,6 +29,7 @@ import com.fumbbl.ffb.server.InjuryResult;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeCrowdPush;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeTTMHitPlayer;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeTTMHitPlayerForSpp;
+import com.fumbbl.ffb.server.model.DropPlayerContext;
 import com.fumbbl.ffb.server.model.SteadyFootingContext;
 import com.fumbbl.ffb.server.net.ReceivedCommand;
 import com.fumbbl.ffb.server.step.AbstractStepWithReRoll;
@@ -41,7 +42,6 @@ import com.fumbbl.ffb.server.step.StepParameter;
 import com.fumbbl.ffb.server.step.StepParameterKey;
 import com.fumbbl.ffb.server.step.StepParameterSet;
 import com.fumbbl.ffb.server.step.action.ttm.UtilThrowTeamMateSequence;
-import com.fumbbl.ffb.server.step.bb2025.command.DropPlayerCommand;
 import com.fumbbl.ffb.server.step.bb2025.command.HitPlayerTurnOverCommand;
 import com.fumbbl.ffb.server.step.mixed.ttm.TtmToCrowdHandler;
 import com.fumbbl.ffb.server.util.UtilServerCatchScatterThrowIn;
@@ -333,11 +333,13 @@ public final class StepInitScatterPlayer extends AbstractStepWithReRoll {
 				|| (!game.isHomePlaying() && game.getTeamAway().hasPlayer(playerLandedUpon)))) {
 				commands.add(new HitPlayerTurnOverCommand());
 			}
-			commands.add(new DropPlayerCommand(playerLandedUpon.getId(), ApothecaryMode.HIT_PLAYER, true));
+
+			DropPlayerContext dropPlayerContext = new DropPlayerContext(injuryResultHitPlayer, false, true,
+				null, playerLandedUpon.getId(), ApothecaryMode.HIT_PLAYER, false);
 
 			getResult().addReport(new ReportPlayerEvent(playerLandedUpon.getId(), "was hit"));
 			publishParameter(new StepParameter(StepParameterKey.STEADY_FOOTING_CONTEXT,
-				new SteadyFootingContext(injuryResultHitPlayer, commands)));
+				new SteadyFootingContext(dropPlayerContext, commands)));
 
 			// continue loop in end step
 			publishParameter(new StepParameter(StepParameterKey.THROWN_PLAYER_COORDINATE, endCoordinate));

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/ttm/StepRightStuff.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/ttm/StepRightStuff.java
@@ -35,6 +35,7 @@ import com.fumbbl.ffb.server.IServerJsonOption;
 import com.fumbbl.ffb.server.InjuryResult;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeTTMLanding;
 import com.fumbbl.ffb.server.injury.injuryType.InjuryTypeFumbledKtmApoKo;
+import com.fumbbl.ffb.server.model.DropPlayerContext;
 import com.fumbbl.ffb.server.model.SteadyFootingContext;
 import com.fumbbl.ffb.server.net.ReceivedCommand;
 import com.fumbbl.ffb.server.step.AbstractStepWithReRoll;
@@ -45,12 +46,10 @@ import com.fumbbl.ffb.server.step.StepParameter;
 import com.fumbbl.ffb.server.step.StepParameterKey;
 import com.fumbbl.ffb.server.step.StepParameterSet;
 import com.fumbbl.ffb.server.step.UtilServerSteps;
-import com.fumbbl.ffb.server.step.bb2025.command.RightStuffCommand;
 import com.fumbbl.ffb.server.util.UtilServerInjury;
 import com.fumbbl.ffb.server.util.UtilServerReRoll;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -253,8 +252,11 @@ public final class StepRightStuff extends AbstractStepWithReRoll {
 		if (!doRoll) {
 			InjuryResult injuryResultThrownPlayer = UtilServerInjury.handleInjury(this, fumbledKtm ? new InjuryTypeFumbledKtmApoKo() : new InjuryTypeTTMLanding(),
 				game.getActingPlayer().getPlayer(), thrownPlayer, playerCoordinate, null, null, ApothecaryMode.THROWN_PLAYER);
-			RightStuffCommand command = new RightStuffCommand(thrownPlayer.getId(), fThrownPlayerHasBall);
-			publishParameter(new StepParameter(StepParameterKey.STEADY_FOOTING_CONTEXT, new SteadyFootingContext(injuryResultThrownPlayer, Collections.singletonList(command))));
+			DropPlayerContext dropPlayerContext = new DropPlayerContext(injuryResultThrownPlayer, fThrownPlayerHasBall, false,
+				null, thrownPlayer.getId(), ApothecaryMode.THROWN_PLAYER, false, false, null, fThrownPlayerHasBall, false,
+				null);
+			publishParameter(new StepParameter(StepParameterKey.STEADY_FOOTING_CONTEXT, new SteadyFootingContext(dropPlayerContext)));
+			publishParameter(new StepParameter(StepParameterKey.THROWN_PLAYER_COORDINATE, null));
 			getResult().setNextAction(StepAction.NEXT_STEP);
 		}
 	}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/BlitzBlock.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/BlitzBlock.java
@@ -86,6 +86,7 @@ public class BlitzBlock extends com.fumbbl.ffb.server.step.generator.BlitzBlock 
 		sequence.add(StepId.PICK_UP, from(StepParameterKey.GOTO_LABEL_ON_FAILURE, IStepLabel.DROP_FALLING_PLAYERS));
 		sequence.jump(IStepLabel.DROP_FALLING_PLAYERS);
 		sequence.add(StepId.FALL_DOWN, IStepLabel.FALL_DOWN);
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 		sequence.jump(IStepLabel.ATTACKER_DROPPED);
 
 		// on blockChoice = SKULL

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/BlitzBlock.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/BlitzBlock.java
@@ -100,6 +100,7 @@ public class BlitzBlock extends com.fumbbl.ffb.server.step.generator.BlitzBlock 
 
 		sequence.add(StepId.STEADY_FOOTING, IStepLabel.ATTACKER_DROPPED, from(StepParameterKey.APOTHECARY_MODE,
 			ApothecaryMode.ATTACKER));
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 		sequence.add(StepId.PLACE_BALL, IStepLabel.ATTACKER_DROPPED);
 
 		sequence.add(StepId.APOTHECARY, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.ATTACKER));

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/BlitzMove.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/BlitzMove.java
@@ -54,6 +54,7 @@ public class BlitzMove extends com.fumbbl.ffb.server.step.generator.BlitzMove {
 		sequence.add(StepId.DROP_DIVING_TACKLER, IStepLabel.FALL_DOWN);
 		sequence.add(StepId.SHADOWING);
 		sequence.add(StepId.FALL_DOWN);
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 		sequence.add(StepId.PLACE_BALL);
 
 		sequence.add(StepId.APOTHECARY, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.DEFENDER));

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/Block.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/Block.java
@@ -98,6 +98,7 @@ public class Block extends com.fumbbl.ffb.server.step.generator.Block {
 
 		sequence.add(StepId.STEADY_FOOTING, IStepLabel.ATTACKER_DROPPED, from(StepParameterKey.APOTHECARY_MODE,
 			ApothecaryMode.ATTACKER));
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 		sequence.add(StepId.PLACE_BALL);
 
 		sequence.add(StepId.APOTHECARY, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.ATTACKER));

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/EndPlayerAction.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/EndPlayerAction.java
@@ -32,6 +32,7 @@ public class EndPlayerAction extends com.fumbbl.ffb.server.step.generator.EndPla
 		sequence.add(StepId.CATCH_SCATTER_THROW_IN);
 		sequence.add(StepId.STALLING_PLAYER, IStepLabel.END_FEEDING);
 		sequence.add(StepId.STEADY_FOOTING, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.HIT_PLAYER));
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 		sequence.add(StepId.PLACE_BALL);
 		sequence.add(StepId.APOTHECARY, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.HIT_PLAYER));
 		sequence.add(StepId.CATCH_SCATTER_THROW_IN);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/EndTurn.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/EndTurn.java
@@ -23,6 +23,7 @@ public class EndTurn extends com.fumbbl.ffb.server.step.generator.EndTurn {
 
 		sequence.add(StepId.FORGONE_STALLING, from(StepParameterKey.CHECK_FORGO, params.isCheckForgo()));
 		sequence.add(StepId.STEADY_FOOTING, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.HIT_PLAYER));
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 		sequence.add(StepId.PLACE_BALL);
 		sequence.add(StepId.APOTHECARY, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.HIT_PLAYER));
 		sequence.add(StepId.CATCH_SCATTER_THROW_IN);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/Move.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/Move.java
@@ -63,6 +63,7 @@ public class Move extends com.fumbbl.ffb.server.step.generator.Move {
 		sequence.add(StepId.DROP_DIVING_TACKLER, IStepLabel.FALL_DOWN);
 		sequence.add(StepId.SHADOWING);
 		sequence.add(StepId.FALL_DOWN);
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 		sequence.add(StepId.PLACE_BALL);
 
 		sequence.add(StepId.APOTHECARY, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.DEFENDER));

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/ScatterPlayer.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/ScatterPlayer.java
@@ -41,6 +41,7 @@ public class ScatterPlayer extends com.fumbbl.ffb.server.step.generator.ScatterP
 
 		sequence.add(StepId.STEADY_FOOTING, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.HIT_PLAYER),
 			from(StepParameterKey.GOTO_LABEL_ON_SUCCESS, IStepLabel.END));
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 		sequence.add(StepId.PLACE_BALL);
 		sequence.add(StepId.APOTHECARY, IStepLabel.APOTHECARY_HIT_PLAYER,
 			from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.HIT_PLAYER));

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/SpecialEffect.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/SpecialEffect.java
@@ -26,6 +26,7 @@ public class SpecialEffect extends com.fumbbl.ffb.server.step.generator.SpecialE
 			from(StepParameterKey.PLAYER_ID, params.getPlayerId()), from(StepParameterKey.ROLL_FOR_EFFECT, params.isRollForEffect()),
 			from(StepParameterKey.GOTO_LABEL_ON_FAILURE, IStepLabel.END_SPECIAL_EFFECT));
 		sequence.add(StepId.STEADY_FOOTING, from(StepParameterKey.GOTO_LABEL_ON_SUCCESS, IStepLabel.END_SPECIAL_EFFECT));
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 		sequence.add(StepId.PLACE_BALL);
 		sequence.add(StepId.APOTHECARY, from(StepParameterKey.APOTHECARY_MODE, ApothecaryMode.SPECIAL_EFFECT));
 		sequence.add(StepId.NEXT_STEP, IStepLabel.END_SPECIAL_EFFECT);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/ThrowTeamMate.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/generator/bb2025/ThrowTeamMate.java
@@ -41,6 +41,7 @@ public class ThrowTeamMate extends com.fumbbl.ffb.server.step.generator.ThrowTea
 			from(StepParameterKey.IS_KICKED_PLAYER, params.isKicked()),
 			from(StepParameterKey.GOTO_LABEL_ON_SUCCESS, IStepLabel.END_SCATTER_PLAYER));
 		sequence.add(StepId.STEADY_FOOTING, from(StepParameterKey.GOTO_LABEL_ON_SUCCESS, IStepLabel.END_SCATTER_PLAYER));
+		sequence.add(StepId.HANDLE_DROP_PLAYER_CONTEXT);
 
 		sequence.jump(IStepLabel.APOTHECARY_THROWN_PLAYER);
 		sequence.add(StepId.EAT_TEAM_MATE, IStepLabel.EAT_TEAM_MATE);


### PR DESCRIPTION
Drafting this to show the direction before I go and convert every injury type.

This is the first pass at moving armour-roll injuries over to the modification-aware flow so Dwarfen Grit can hook into them consistently.

Current commits:
- `Pass injury coordinates to modification-aware hooks`
  Needed so converted injury types still have the coordinates they used before.
- `Route failed falls through drop player context`
  Lets failed dodge/fall paths go through the existing modified-injury prompt handling.
- `Make failed dodge injuries modification-aware`
  Converts `DropDodge` / `DropDodgeForSpp` and adds them to Dwarfen Grit.
  
The PR touches a bunch of files, but most of that is mechanical from passing the extra coordinates through the existing modification-aware hook. The important bits to review are:
- `ModificationAwareInjuryTypeServer`
- `StepFallDown` / the fall sequence changes
- `InjuryTypeDropDodge`
- `InjuryTypeDropDodgeForSpp`
- `DwarfenGritModification`

If this looks like the right direction, I'll keep adding the other armour-roll injury types here.