### PR TITLE
Move active cards under inducements

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -27,6 +27,7 @@ public class ChangeList {
 			.addBugfix("Using OtB vs G&G pass caused the game to crash if the passer moved on")
 			.addImprovement("Used-player marking now shows a dedicated icon for the player who used the team's blitz action")
 			.addBugfix("Self inflicted injuries never triggered Getting Even")
+			.addImprovement("Moved active cards into the inducements menu to reduce top-level menu width")
 		);
 
 		versions.add(new VersionChangeList("3.2.3")

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/GameMenuBar.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/GameMenuBar.java
@@ -111,9 +111,6 @@ public class GameMenuBar extends JMenuBar implements ActionListener, IDialogClos
 		inducementsMenu = new InducementsMenu(getClient(), dimensionProvider, styleProvider, layoutSettings);
 		add(inducementsMenu);
 
-		CardsMenu cardsMenu = new CardsMenu(getClient(), dimensionProvider, styleProvider, layoutSettings);
-		add(cardsMenu);
-
 		PrayersMenu prayersMenu = new PrayersMenu(getClient(), dimensionProvider, styleProvider, layoutSettings);
 		add(prayersMenu);
 

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/InducementsMenu.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/InducementsMenu.java
@@ -39,7 +39,6 @@ public class InducementsMenu extends FfbMenu {
 	private int fCurrentInducementTotalAway;
 	private int fCurrentUsedCardsAway;
 	private final CardsMenu cardsMenu;
-	private boolean fCurrentHasCardTypes;
 
 	protected InducementsMenu(FantasyFootballClient client, DimensionProvider dimensionProvider, StyleProvider styleProvider, LayoutSettings layoutSettings) {
 		super("Inducements", client, dimensionProvider, styleProvider, layoutSettings);
@@ -55,7 +54,6 @@ public class InducementsMenu extends FfbMenu {
 		fCurrentInducementTotalAway = -1;
 		fCurrentUsedCardsAway = 0;
 		cardsMenu.init();
-		fCurrentHasCardTypes = false;
 	}
 
 	@Override

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/InducementsMenu.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/InducementsMenu.java
@@ -1,7 +1,6 @@
 package com.fumbbl.ffb.client.ui.menu;
 
 import com.fumbbl.ffb.ClientMode;
-import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.IIconProperty;
 import com.fumbbl.ffb.PlayerType;
 import com.fumbbl.ffb.client.DimensionProvider;
@@ -11,7 +10,6 @@ import com.fumbbl.ffb.client.StyleProvider;
 import com.fumbbl.ffb.client.UserInterface;
 import com.fumbbl.ffb.client.ui.swing.JMenu;
 import com.fumbbl.ffb.client.ui.swing.JMenuItem;
-import com.fumbbl.ffb.factory.CardTypeFactory;
 import com.fumbbl.ffb.inducement.Card;
 import com.fumbbl.ffb.inducement.CardType;
 import com.fumbbl.ffb.inducement.Inducement;

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/InducementsMenu.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/InducementsMenu.java
@@ -16,6 +16,8 @@ import com.fumbbl.ffb.inducement.Card;
 import com.fumbbl.ffb.inducement.CardType;
 import com.fumbbl.ffb.inducement.Inducement;
 import com.fumbbl.ffb.inducement.Usage;
+import com.fumbbl.ffb.mechanics.GameMechanic;
+import com.fumbbl.ffb.mechanics.Mechanic;
 import com.fumbbl.ffb.model.Game;
 import com.fumbbl.ffb.model.InducementSet;
 import com.fumbbl.ffb.model.Player;
@@ -60,8 +62,8 @@ public class InducementsMenu extends FfbMenu {
 	public boolean refresh() {
 		boolean refreshNecessary = false;
 		Game game = client.getGame();
-		boolean hasCardTypes = hasCardTypes(game);
-		if (hasCardTypes) {
+		boolean supportsCards = supportsCards(game);
+		if (supportsCards) {
 			cardsMenu.refresh();
 		}
 
@@ -125,7 +127,7 @@ public class InducementsMenu extends FfbMenu {
 				setEnabled(false);
 			}
 
-			if (hasCardTypes) {
+			if (supportsCards) {
 				add(cardsMenu);
 			}
 
@@ -261,13 +263,13 @@ public class InducementsMenu extends FfbMenu {
 		return Arrays.stream(allCards).collect(Collectors.groupingBy(Card::getType));
 	}
 
-	private boolean hasCardTypes(Game game) {
+	private boolean supportsCards(Game game) {
 		if (game == null || !game.getRules().isInitialized()) {
 			return false;
 		}
 
-		CardTypeFactory cardTypeFactory = game.getFactory(FactoryType.Factory.CARD_TYPE);
-		return cardTypeFactory != null && !cardTypeFactory.getCardTypes().isEmpty();
+		GameMechanic mechanic = game.getMechanic(Mechanic.Type.GAME);
+		return mechanic.supportsCards();
 	}
 
 	@Override

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/InducementsMenu.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/menu/InducementsMenu.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.client.ui.menu;
 
 import com.fumbbl.ffb.ClientMode;
+import com.fumbbl.ffb.FactoryType;
 import com.fumbbl.ffb.IIconProperty;
 import com.fumbbl.ffb.PlayerType;
 import com.fumbbl.ffb.client.DimensionProvider;
@@ -10,6 +11,7 @@ import com.fumbbl.ffb.client.StyleProvider;
 import com.fumbbl.ffb.client.UserInterface;
 import com.fumbbl.ffb.client.ui.swing.JMenu;
 import com.fumbbl.ffb.client.ui.swing.JMenuItem;
+import com.fumbbl.ffb.factory.CardTypeFactory;
 import com.fumbbl.ffb.inducement.Card;
 import com.fumbbl.ffb.inducement.CardType;
 import com.fumbbl.ffb.inducement.Inducement;
@@ -36,9 +38,12 @@ public class InducementsMenu extends FfbMenu {
 	private int fCurrentUsedCardsHome;
 	private int fCurrentInducementTotalAway;
 	private int fCurrentUsedCardsAway;
+	private final CardsMenu cardsMenu;
+	private boolean fCurrentHasCardTypes;
 
 	protected InducementsMenu(FantasyFootballClient client, DimensionProvider dimensionProvider, StyleProvider styleProvider, LayoutSettings layoutSettings) {
 		super("Inducements", client, dimensionProvider, styleProvider, layoutSettings);
+		cardsMenu = new CardsMenu(client, dimensionProvider, styleProvider, layoutSettings);
 		setMnemonic(KeyEvent.VK_I);
 		setEnabled(false);
 	}
@@ -49,12 +54,18 @@ public class InducementsMenu extends FfbMenu {
 		fCurrentUsedCardsHome = 0;
 		fCurrentInducementTotalAway = -1;
 		fCurrentUsedCardsAway = 0;
+		cardsMenu.init();
+		fCurrentHasCardTypes = false;
 	}
 
 	@Override
 	public boolean refresh() {
 		boolean refreshNecessary = false;
 		Game game = client.getGame();
+		boolean hasCardTypes = hasCardTypes(game);
+		if (hasCardTypes) {
+			cardsMenu.refresh();
+		}
 
 		InducementSet inducementSetHome = game.getTurnDataHome().getInducementSet();
 		int totalInducementHome = inducementSetHome.totalInducements();
@@ -114,6 +125,10 @@ public class InducementsMenu extends FfbMenu {
 			} else {
 				setText("No Inducements");
 				setEnabled(false);
+			}
+
+			if (hasCardTypes) {
+				add(cardsMenu);
 			}
 
 		}
@@ -246,6 +261,15 @@ public class InducementsMenu extends FfbMenu {
 		Card[] allCards = pInducementSet.getAllCards();
 
 		return Arrays.stream(allCards).collect(Collectors.groupingBy(Card::getType));
+	}
+
+	private boolean hasCardTypes(Game game) {
+		if (game == null || !game.getRules().isInitialized()) {
+			return false;
+		}
+
+		CardTypeFactory cardTypeFactory = game.getFactory(FactoryType.Factory.CARD_TYPE);
+		return cardTypeFactory != null && !cardTypeFactory.getCardTypes().isEmpty();
 	}
 
 	@Override

--- a/ffb-common/src/main/java/com/fumbbl/ffb/mechanics/GameMechanic.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/mechanics/GameMechanic.java
@@ -67,4 +67,6 @@ public abstract class GameMechanic implements Mechanic {
 	public abstract boolean playersForGoActivations(Game game);
 
 	public abstract boolean isWisdomAvailable(Game game, Player<?> player);
+
+	public abstract boolean supportsCards();
 }

--- a/ffb-common/src/main/java/com/fumbbl/ffb/mechanics/bb2016/GameMechanic.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/mechanics/bb2016/GameMechanic.java
@@ -195,4 +195,9 @@ public class GameMechanic extends com.fumbbl.ffb.mechanics.GameMechanic {
 	public boolean isWisdomAvailable(Game game, Player<?> player){
 		return false;
 	}
+
+	@Override
+	public boolean supportsCards() {
+		return true;
+	}
 }

--- a/ffb-common/src/main/java/com/fumbbl/ffb/mechanics/bb2020/GameMechanic.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/mechanics/bb2020/GameMechanic.java
@@ -239,4 +239,9 @@ public class GameMechanic extends com.fumbbl.ffb.mechanics.GameMechanic {
 			.anyMatch(teamMate -> teamMate.hasSkillProperty(NamedProperties.canGrantSkillsToTeamMates)
 				&& !teamMate.isUsed(NamedProperties.canGrantSkillsToTeamMates));
 	}
+
+	@Override
+	public boolean supportsCards() {
+		return false;
+	}
 }

--- a/ffb-common/src/main/java/com/fumbbl/ffb/mechanics/bb2025/GameMechanic.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/mechanics/bb2025/GameMechanic.java
@@ -245,4 +245,9 @@ public class GameMechanic extends com.fumbbl.ffb.mechanics.GameMechanic {
 			});
 	}
 
+	@Override
+	public boolean supportsCards() {
+		return false;
+	}
+
 }


### PR DESCRIPTION
This reduces the top-level menu width a bit for portrait layout.

I only moved active cards because cards are inducements. Inducements and prayers stay top-level since they are useful to see without clicking, and prayers can come from different places depending on the ruleset.

Changes:
- Removed `CardsMenu` from the top-level `GameMenuBar`.
- Added it under `InducementsMenu`.
- Only show the nested cards entry when the initialized rules expose card types.
- This means the cards entry does not show for BB2025, where no card types are registered.

Note: this reuses the existing `CardsMenu` behavior instead of changing the active-card display itself.