### PR TITLE
Layout - Phase 7 - Pitch viewport transforms

### DIFF
--- a/docs/fullscreen-layout-plan.md
+++ b/docs/fullscreen-layout-plan.md
@@ -35,7 +35,7 @@ The main issue is that transform logic exists, but it is spread across multiple 
 
 ## Proposed Direction
 
-Introduce a pitch viewport/transform abstraction that owns:
+Introduce a pitch viewport/transform abstraction that initially centralizes current field-local coordinate behavior, and later owns:
 
 - the pitch viewport rectangle in UI/screen space
 - world-to-screen conversion
@@ -59,16 +59,17 @@ Add a new client-side abstraction that reproduces the current behavior:
 
 ```java
 public class PitchViewport {
-  public Rectangle getBounds();
-  public Point2D worldToScreen(FieldCoordinate coordinate);
-  public FieldCoordinate screenToWorld(Point point);
-  public Rectangle2D worldSquareToScreen(FieldCoordinate coordinate);
-  public Direction worldToScreen(Direction direction);
-  public double getScale();
+  public Dimension fieldSize();
+  public int squareSize();
+  public int imageOffset();
+  public Dimension toLocal(FieldCoordinate coordinate);
+  public Dimension toLocal(FieldCoordinate coordinate, boolean center);
+  public FieldCoordinate toFieldCoordinate(Point localPoint);
+  public Direction toLocal(Direction direction);
 }
 ```
 
-This API is illustrative. The real implementation may need separate methods for square origin, square center, and square bounds to avoid ambiguous rounding behavior.
+This first API should use current-code terminology and preserve existing behavior. Do not introduce `worldToScreen` / `screenToWorld` yet because the viewport does not own screen bounds at this stage.
 
 At this stage it can still use existing `LayoutSettings`, `ClientLayout`, and fixed component sizes internally. The purpose is to move responsibility first, not change behavior.
 
@@ -86,7 +87,7 @@ These tests should lock down existing behavior so later dynamic layout changes a
 
 ## Phase 3: Route Input Through The Viewport
 
-Update `CoordinateConverter` so it delegates to `PitchViewport.screenToWorld(...)`.
+Update `CoordinateConverter` so it delegates to `PitchViewport.toFieldCoordinate(...)`.
 
 This is a low-risk first migration because normal field mouse handling already goes through `CoordinateConverter`.
 
@@ -94,7 +95,7 @@ Special drag/drop behavior in `UtilClientPlayerDrag` can stay as-is initially, t
 
 ## Phase 4: Route Common Rendering Through The Viewport
 
-Update common `FieldLayer` helpers to use `PitchViewport.worldToScreen(...)` and `PitchViewport.worldSquareToScreen(...)`.
+Update common `FieldLayer` helpers to use `PitchViewport.toLocal(...)` and `PitchViewport.squareSize()`.
 
 Then gradually migrate direct `pitchDimensionProvider.mapToLocal(...)` calls in individual field layers, states, animations, sketches, range rulers, and marker popup placement.
 
@@ -134,7 +135,18 @@ Initial behavior should remain visually identical:
 
 This creates a bridge from the current fixed model to a dynamic layout pass.
 
-## Phase 7: Split GUI Scale From Pitch Scale
+## Phase 7: Promote Local Mapping To Viewport Transforms
+
+After the layout result exists and `PitchViewport` owns the calculated pitch bounds, introduce viewport terminology:
+
+- `worldToScreen(FieldCoordinate)`
+- `screenToWorld(Point)`
+
+Until then, keep `toLocal(...)` and `toFieldCoordinate(...)` because current methods return field-component-local coordinates.
+
+At this point, decide whether to keep the old methods as compatibility wrappers or migrate callers to the new names.
+
+## Phase 8: Split GUI Scale From Pitch Scale
 
 Separate the existing broad `LayoutSettings.scale` behavior into clearer concepts:
 
@@ -145,7 +157,7 @@ Initially, preserve current behavior by applying the existing scale value as GUI
 
 Once dynamic layout is active, GUI scale should affect how much space non-pitch UI components request. Pitch scale should be calculated from the remaining pitch viewport and should preserve the pitch aspect ratio.
 
-## Phase 8: Make The Window Resizable
+## Phase 9: Make The Window Resizable
 
 Once the viewport and layout result exist, allow the frame to resize.
 
@@ -159,7 +171,7 @@ On resize:
 
 This is the first point where the new architecture is tested against real changing window sizes.
 
-## Phase 9: Fit Pitch To Available Space
+## Phase 10: Fit Pitch To Available Space
 
 Implement the dynamic pitch sizing logic:
 
@@ -176,11 +188,11 @@ The pitch viewport should generate `AffineTransform` instances for:
 - `worldToScreen`
 - `screenToWorld`
 
-Tile boundaries should come from the transform rather than repeated integer square-size calculations.
+The pitch viewport should update these transforms from the calculated field bounds. Tile boundaries should come from the transform rather than repeated integer square-size calculations.
 
 This pitch scale should be independent from GUI scale. GUI scale affects how much space the non-pitch components need; pitch scale is then derived from the remaining viewport.
 
-## Phase 10: Move GUI To Rule-Based Placement
+## Phase 11: Move GUI To Rule-Based Placement
 
 Move non-pitch GUI components toward rule-based placement:
 
@@ -191,7 +203,7 @@ Move non-pitch GUI components toward rule-based placement:
 
 This is where the client starts moving away from fixed `ClientLayout` variants.
 
-## Phase 11: Fullscreen
+## Phase 12: Fullscreen
 
 Once resizing works, fullscreen should mostly be:
 

--- a/docs/fullscreen-layout-plan.md
+++ b/docs/fullscreen-layout-plan.md
@@ -91,7 +91,7 @@ Update `CoordinateConverter` so it delegates to `PitchViewport.toFieldCoordinate
 
 This is a low-risk first migration because normal field mouse handling already goes through `CoordinateConverter`.
 
-Special drag/drop behavior in `UtilClientPlayerDrag` can stay as-is initially, then be migrated after normal pitch input is stable.
+Special drag/drop behavior in `UtilClientPlayerDrag` is intentionally excluded from this initial input migration. It has different edge behavior from `CoordinateConverter`, handles field/box crossing, and can produce reserve/box sentinel coordinates. It is handled separately in Phase 5.
 
 ## Phase 4: Route Common Rendering Through The Viewport
 
@@ -99,7 +99,23 @@ Update common `FieldLayer` helpers to use `PitchViewport.toLocal(...)` and `Pitc
 
 Then gradually migrate direct `pitchDimensionProvider.mapToLocal(...)` calls in individual field layers, states, animations, sketches, range rulers, and marker popup placement.
 
-## Phase 5: Introduce A Layout Result
+This phase covers rendering and UI placement coordinate mapping. It does not include setup drag/drop input, which is handled separately in Phase 5.
+
+## Phase 5: Handle Setup Drag/Drop Coordinate Mapping
+
+Evaluate `UtilClientPlayerDrag` separately from normal field input. Setup drag/drop has different edge behavior from `CoordinateConverter`, handles field/box crossing, and can produce reserve/box sentinel coordinates.
+
+Before changing it, add tests that pin current behavior for:
+
+- field edge coordinates
+- portrait conversion
+- box-to-field dragging
+- field-to-box dragging
+- reserve/box sentinel coordinates
+
+Then decide whether this belongs in `PitchViewport` as a dedicated drag method or in a separate drag/drop coordinate mapper.
+
+## Phase 6: Introduce A Layout Result
 
 Add a small object that represents the result of a client layout pass:
 
@@ -122,7 +138,7 @@ The layout pass should take GUI scale into account when calculating non-pitch co
 
 The important shift is that layout becomes data calculated by one component, instead of being implicit in nested Swing panels.
 
-## Phase 6: Make UserInterface Consume The Layout Result
+## Phase 7: Make UserInterface Consume The Layout Result
 
 Refactor `UserInterface.initComponents(...)` so it consumes `ClientLayoutResult`.
 
@@ -135,7 +151,7 @@ Initial behavior should remain visually identical:
 
 This creates a bridge from the current fixed model to a dynamic layout pass.
 
-## Phase 7: Promote Local Mapping To Viewport Transforms
+## Phase 8: Promote Local Mapping To Viewport Transforms
 
 After the layout result exists and `PitchViewport` owns the calculated pitch bounds, introduce viewport terminology:
 
@@ -146,7 +162,7 @@ Until then, keep `toLocal(...)` and `toFieldCoordinate(...)` because current met
 
 At this point, decide whether to keep the old methods as compatibility wrappers or migrate callers to the new names.
 
-## Phase 8: Split GUI Scale From Pitch Scale
+## Phase 9: Split GUI Scale From Pitch Scale
 
 Separate the existing broad `LayoutSettings.scale` behavior into clearer concepts:
 
@@ -157,7 +173,7 @@ Initially, preserve current behavior by applying the existing scale value as GUI
 
 Once dynamic layout is active, GUI scale should affect how much space non-pitch UI components request. Pitch scale should be calculated from the remaining pitch viewport and should preserve the pitch aspect ratio.
 
-## Phase 9: Make The Window Resizable
+## Phase 10: Make The Window Resizable
 
 Once the viewport and layout result exist, allow the frame to resize.
 
@@ -171,7 +187,7 @@ On resize:
 
 This is the first point where the new architecture is tested against real changing window sizes.
 
-## Phase 10: Fit Pitch To Available Space
+## Phase 11: Fit Pitch To Available Space
 
 Implement the dynamic pitch sizing logic:
 
@@ -192,7 +208,7 @@ The pitch viewport should update these transforms from the calculated field boun
 
 This pitch scale should be independent from GUI scale. GUI scale affects how much space the non-pitch components need; pitch scale is then derived from the remaining viewport.
 
-## Phase 11: Move GUI To Rule-Based Placement
+## Phase 12: Move GUI To Rule-Based Placement
 
 Move non-pitch GUI components toward rule-based placement:
 
@@ -203,7 +219,7 @@ Move non-pitch GUI components toward rule-based placement:
 
 This is where the client starts moving away from fixed `ClientLayout` variants.
 
-## Phase 12: Fullscreen
+## Phase 13: Fullscreen
 
 Once resizing works, fullscreen should mostly be:
 

--- a/docs/fullscreen-layout-plan.md
+++ b/docs/fullscreen-layout-plan.md
@@ -91,7 +91,7 @@ Update `CoordinateConverter` so it delegates to `PitchViewport.toFieldCoordinate
 
 This is a low-risk first migration because normal field mouse handling already goes through `CoordinateConverter`.
 
-Special drag/drop behavior in `UtilClientPlayerDrag` is intentionally excluded from this initial input migration. It has different edge behavior from `CoordinateConverter`, handles field/box crossing, and can produce reserve/box sentinel coordinates. It is handled separately in Phase 5.
+Special drag/drop behavior in `UtilClientPlayerDrag` is intentionally excluded from this initial input migration. It has different edge behavior from `CoordinateConverter`, handles field/box crossing, and can produce reserve/box sentinel coordinates. It is handled separately after the layout result and viewport bounds exist.
 
 ## Phase 4: Route Common Rendering Through The Viewport
 
@@ -99,23 +99,9 @@ Update common `FieldLayer` helpers to use `PitchViewport.toLocal(...)` and `Pitc
 
 Then gradually migrate direct `pitchDimensionProvider.mapToLocal(...)` calls in individual field layers, states, animations, sketches, range rulers, and marker popup placement.
 
-This phase covers rendering and UI placement coordinate mapping. It does not include setup drag/drop input, which is handled separately in Phase 5.
+This phase covers rendering and UI placement coordinate mapping. It does not include setup drag/drop input, which is handled separately after layout bounds exist.
 
-## Phase 5: Handle Setup Drag/Drop Coordinate Mapping
-
-Evaluate `UtilClientPlayerDrag` separately from normal field input. Setup drag/drop has different edge behavior from `CoordinateConverter`, handles field/box crossing, and can produce reserve/box sentinel coordinates.
-
-Before changing it, add tests that pin current behavior for:
-
-- field edge coordinates
-- portrait conversion
-- box-to-field dragging
-- field-to-box dragging
-- reserve/box sentinel coordinates
-
-Then decide whether this belongs in `PitchViewport` as a dedicated drag method or in a separate drag/drop coordinate mapper.
-
-## Phase 6: Introduce A Layout Result
+## Phase 5: Introduce A Layout Result
 
 Add a small object that represents the result of a client layout pass:
 
@@ -138,7 +124,7 @@ The layout pass should take GUI scale into account when calculating non-pitch co
 
 The important shift is that layout becomes data calculated by one component, instead of being implicit in nested Swing panels.
 
-## Phase 7: Make UserInterface Consume The Layout Result
+## Phase 6: Make UserInterface Consume The Layout Result
 
 Refactor `UserInterface.initComponents(...)` so it consumes `ClientLayoutResult`.
 
@@ -151,7 +137,7 @@ Initial behavior should remain visually identical:
 
 This creates a bridge from the current fixed model to a dynamic layout pass.
 
-## Phase 8: Promote Local Mapping To Viewport Transforms
+## Phase 7: Promote Local Mapping To Viewport Transforms
 
 After the layout result exists and `PitchViewport` owns the calculated pitch bounds, introduce viewport terminology:
 
@@ -161,6 +147,20 @@ After the layout result exists and `PitchViewport` owns the calculated pitch bou
 Until then, keep `toLocal(...)` and `toFieldCoordinate(...)` because current methods return field-component-local coordinates.
 
 At this point, decide whether to keep the old methods as compatibility wrappers or migrate callers to the new names.
+
+## Phase 8: Handle Setup Drag/Drop Coordinate Mapping
+
+Evaluate `UtilClientPlayerDrag` after the layout result exists and `PitchViewport` owns calculated pitch bounds. Setup drag/drop has different edge behavior from `CoordinateConverter`, handles field/box crossing, and can produce reserve/box sentinel coordinates.
+
+Before changing it, add or maintain tests that pin current behavior for:
+
+- field edge coordinates
+- portrait conversion
+- box-to-field dragging
+- field-to-box dragging
+- reserve/box sentinel coordinates
+
+Then design a layout-aware setup drag/drop mapper. This should probably be separate from `PitchViewport`: the viewport should own pitch coordinate transforms, while setup drag/drop hit testing should interpret pitch, box, and crossing behavior for the current interaction mode.
 
 ## Phase 9: Split GUI Scale From Pitch Scale
 

--- a/docs/fullscreen-layout-plan.md
+++ b/docs/fullscreen-layout-plan.md
@@ -1,0 +1,199 @@
+# Fullscreen And Dynamic Pitch Layout Plan
+
+## Goal
+
+Move the client toward a game-style layout model where the pitch is treated as the world and the Swing GUI is laid out around it. The layout should eventually respond to the current window size, compute the available pitch viewport, and use explicit transforms to convert between pitch/world coordinates and screen/UI coordinates.
+
+The first phase should preserve current behavior. Fullscreen and fully dynamic resizing should come later, after coordinate conversion and pitch rendering are centralized.
+
+## Scale Concepts
+
+The dynamic layout should separate pitch scaling from GUI scaling.
+
+- Pitch scale should be derived from the available pitch viewport and the fixed world size of the pitch.
+- GUI scale should be a user setting that controls non-pitch UI sizes such as sidebars, chat, log, buttons, icons, fonts, timers, and menus.
+
+This allows users on large high-resolution screens to make the GUI larger without forcing the pitch transform to use the same scale. The pitch should still fit the available area while preserving its aspect ratio.
+
+The current `LayoutSettings.scale` behaves like a broad client scale. During the refactor, it may need to become more explicit, for example:
+
+- `guiScale` for non-pitch components
+- viewport-derived pitch scale for the pitch/world transform
+
+Existing scale behavior should be preserved first, then split once the layout/viewport responsibilities are clear.
+
+## Current Foundation
+
+- `FieldCoordinate` already represents pitch/world coordinates.
+- `PitchDimensionProvider` already handles much of the field-to-pixel mapping.
+- `CoordinateConverter` already handles mouse-to-field conversion.
+- `FieldLayer` and several field layer subclasses use `PitchDimensionProvider.mapToLocal(...)` for rendering.
+- `UserInterface` currently builds fixed layouts using `ClientLayout`, `Component`, `LayoutSettings`, `BoxLayout`, and `pack()`.
+
+The main issue is that transform logic exists, but it is spread across multiple classes rather than being represented as one explicit viewport/camera-style abstraction.
+
+## Proposed Direction
+
+Introduce a pitch viewport/transform abstraction that owns:
+
+- the pitch viewport rectangle in UI/screen space
+- world-to-screen conversion
+- screen-to-world conversion
+- square/tile bounds
+- scale
+- orientation handling
+- direction remapping where needed
+
+Possible names:
+
+- `PitchViewport`
+- `PitchTransform`
+- `PitchCamera`
+
+`PitchViewport` is probably the clearest name if the class owns both the screen rectangle and the transforms.
+
+## Phase 1: Centralize Pitch Transform
+
+Add a new client-side abstraction that reproduces the current behavior:
+
+```java
+public class PitchViewport {
+  public Rectangle getBounds();
+  public Point2D worldToScreen(FieldCoordinate coordinate);
+  public FieldCoordinate screenToWorld(Point point);
+  public Rectangle2D worldSquareToScreen(FieldCoordinate coordinate);
+  public Direction worldToScreen(Direction direction);
+  public double getScale();
+}
+```
+
+At this stage it can still use existing `LayoutSettings`, `ClientLayout`, and fixed component sizes internally. The purpose is to move responsibility first, not change behavior.
+
+## Phase 2: Add Mapping Tests
+
+Add focused tests before changing rendering behavior:
+
+- landscape field coordinate to screen coordinate
+- portrait field coordinate to screen coordinate
+- screen coordinate to field coordinate
+- portrait direction remapping
+- bounds/edge behavior
+
+These tests should lock down existing behavior so later dynamic layout changes are safer.
+
+## Phase 3: Route Input Through The Viewport
+
+Update `CoordinateConverter` so it delegates to `PitchViewport.screenToWorld(...)`.
+
+This is a low-risk first migration because normal field mouse handling already goes through `CoordinateConverter`.
+
+Special drag/drop behavior in `UtilClientPlayerDrag` can stay as-is initially, then be migrated after normal pitch input is stable.
+
+## Phase 4: Route Common Rendering Through The Viewport
+
+Update common `FieldLayer` helpers to use `PitchViewport.worldToScreen(...)` and `PitchViewport.worldSquareToScreen(...)`.
+
+Then gradually migrate direct `pitchDimensionProvider.mapToLocal(...)` calls in individual field layers, states, animations, sketches, range rulers, and marker popup placement.
+
+## Phase 5: Introduce A Layout Result
+
+Add a small object that represents the result of a client layout pass:
+
+```java
+public class ClientLayoutResult {
+  public Rectangle fieldBounds;
+  public Rectangle homeSidebarBounds;
+  public Rectangle awaySidebarBounds;
+  public Rectangle scoreBarBounds;
+  public Rectangle logBounds;
+  public Rectangle chatBounds;
+}
+```
+
+Initially this result can reproduce the current fixed `LANDSCAPE`, `PORTRAIT`, `SQUARE`, and `WIDE` layouts.
+
+The layout pass should take GUI scale into account when calculating non-pitch component sizes. The pitch viewport should then be calculated from whatever space remains.
+
+The important shift is that layout becomes data calculated by one component, instead of being implicit in nested Swing panels.
+
+## Phase 6: Make UserInterface Consume The Layout Result
+
+Refactor `UserInterface.initComponents(...)` so it consumes `ClientLayoutResult`.
+
+Initial behavior should remain visually identical:
+
+- same fixed window size
+- same component sizes
+- same layout variants
+- same `pack()` behavior
+
+This creates a bridge from the current fixed model to a dynamic layout pass.
+
+## Phase 7: Split GUI Scale From Pitch Scale
+
+Separate the existing broad `LayoutSettings.scale` behavior into clearer concepts:
+
+- GUI scale for non-pitch components, fonts, icons, sidebars, chat, log, timers, and menus
+- pitch scale derived from the pitch viewport size
+
+Initially, preserve current behavior by applying the existing scale value as GUI scale and letting the fixed pitch viewport reproduce the old pitch size.
+
+Once dynamic layout is active, GUI scale should affect how much space non-pitch UI components request. Pitch scale should be calculated from the remaining pitch viewport and should preserve the pitch aspect ratio.
+
+## Phase 8: Make The Window Resizable
+
+Once the viewport and layout result exist, allow the frame to resize.
+
+On resize:
+
+- read the current content size
+- recompute the layout result
+- update component bounds
+- update the pitch viewport transform
+- recreate/redraw field layer buffers as needed
+
+This is the first point where the new architecture is tested against real changing window sizes.
+
+## Phase 9: Fit Pitch To Available Space
+
+Implement the dynamic pitch sizing logic:
+
+```text
+available pitch area = remaining rectangle after GUI placement
+scale = min(availableWidth / 26, availableHeight / 15)
+pitchWidth = 26 * scale
+pitchHeight = 15 * scale
+center pitch inside available area
+```
+
+The pitch viewport should generate `AffineTransform` instances for:
+
+- `worldToScreen`
+- `screenToWorld`
+
+Tile boundaries should come from the transform rather than repeated integer square-size calculations.
+
+This pitch scale should be independent from GUI scale. GUI scale affects how much space the non-pitch components need; pitch scale is then derived from the remaining viewport.
+
+## Phase 10: Move GUI To Rule-Based Placement
+
+Move non-pitch GUI components toward rule-based placement:
+
+- sidebars pinned to left/right when wide enough
+- log/chat placed bottom or side depending on available shape
+- score/status/timer components pinned to top or bottom
+- pitch takes the remaining available area
+
+This is where the client starts moving away from fixed `ClientLayout` variants.
+
+## Phase 11: Fullscreen
+
+Once resizing works, fullscreen should mostly be:
+
+- switch Java window/display mode
+- get available screen bounds
+- run the same layout pass
+- update the same pitch viewport
+- redraw
+
+No special pitch coordinate logic should be needed for fullscreen.

--- a/docs/fullscreen-layout-plan.md
+++ b/docs/fullscreen-layout-plan.md
@@ -103,6 +103,24 @@ This phase covers rendering and UI placement coordinate mapping. It does not inc
 
 ## Phase 5: Introduce A Layout Result
 
+The layout responsibilities should be split like this:
+
+```text
+Component enum / UiDimensionProvider
+  gives fixed component sizes
+
+ClientLayoutCalculator
+  places those sizes into a window layout
+
+ClientLayoutResult
+  stores the resulting bounds
+
+UserInterface / PitchViewport
+  consume those bounds
+```
+
+At first the calculator should reproduce the current fixed layout. Later phases can change the calculator to use the available window size, GUI scale, and pitch aspect ratio without spreading that logic through `UserInterface`.
+
 Add a small object that represents the result of a client layout pass:
 
 ```java

--- a/docs/fullscreen-layout-plan.md
+++ b/docs/fullscreen-layout-plan.md
@@ -15,7 +15,7 @@ The dynamic layout should separate pitch scaling from GUI scaling.
 
 This allows users on large high-resolution screens to make the GUI larger without forcing the pitch transform to use the same scale. The pitch should still fit the available area while preserving its aspect ratio.
 
-The current `LayoutSettings.scale` behaves like a broad client scale. During the refactor, it may need to become more explicit, for example:
+The current `LayoutSettings.scale` is applied by `DimensionProvider` across UI, pitch, and dugout render contexts. Pitch and dugout sizing also apply layout-specific multipliers via `ClientLayout.getPitchScale()` and `ClientLayout.getDugoutScale()`. During the refactor, this may need to become more explicit, for example:
 
 - `guiScale` for non-pitch components
 - viewport-derived pitch scale for the pitch/world transform
@@ -24,9 +24,10 @@ Existing scale behavior should be preserved first, then split once the layout/vi
 
 ## Current Foundation
 
-- `FieldCoordinate` already represents pitch/world coordinates.
+- `FieldCoordinate` already represents field grid coordinates, and also encodes box/dugout positions through sentinel x values.
 - `PitchDimensionProvider` already handles much of the field-to-pixel mapping.
-- `CoordinateConverter` already handles mouse-to-field conversion.
+- `CoordinateConverter` already handles normal field mouse-to-field conversion.
+- Setup drag/drop has additional coordinate conversion in `UtilClientPlayerDrag` because it spans the field and box/dugout UI.
 - `FieldLayer` and several field layer subclasses use `PitchDimensionProvider.mapToLocal(...)` for rendering.
 - `UserInterface` currently builds fixed layouts using `ClientLayout`, `Component`, `LayoutSettings`, `BoxLayout`, and `pack()`.
 
@@ -66,6 +67,8 @@ public class PitchViewport {
   public double getScale();
 }
 ```
+
+This API is illustrative. The real implementation may need separate methods for square origin, square center, and square bounds to avoid ambiguous rounding behavior.
 
 At this stage it can still use existing `LayoutSettings`, `ClientLayout`, and fixed component sizes internally. The purpose is to move responsibility first, not change behavior.
 
@@ -110,6 +113,8 @@ public class ClientLayoutResult {
 }
 ```
 
+This example is not exhaustive. It should include whatever component bounds the current client needs, including any replay/status/menu areas that remain outside the pitch.
+
 Initially this result can reproduce the current fixed `LANDSCAPE`, `PORTRAIT`, `SQUARE`, and `WIDE` layouts.
 
 The layout pass should take GUI scale into account when calculating non-pitch component sizes. The pitch viewport should then be calculated from whatever space remains.
@@ -122,7 +127,7 @@ Refactor `UserInterface.initComponents(...)` so it consumes `ClientLayoutResult`
 
 Initial behavior should remain visually identical:
 
-- same fixed window size
+- same packed window size
 - same component sizes
 - same layout variants
 - same `pack()` behavior

--- a/docs/fullscreen-layout-plan.md
+++ b/docs/fullscreen-layout-plan.md
@@ -113,10 +113,13 @@ ClientLayoutCalculator
   places those sizes into a window layout
 
 ClientLayoutResult
-  stores the resulting bounds
+  stores the resulting final component bounds
+
+ClientLayoutPanel
+  applies those bounds to Swing components
 
 UserInterface / PitchViewport
-  consume those bounds
+  consume the layout result at their own boundaries
 ```
 
 At first the calculator should reproduce the current fixed layout. Later phases can change the calculator to use the available window size, GUI scale, and pitch aspect ratio without spreading that logic through `UserInterface`.
@@ -134,7 +137,16 @@ public class ClientLayoutResult {
 }
 ```
 
-This example is not exhaustive. It should include whatever component bounds the current client needs, including any replay/status/menu areas that remain outside the pitch.
+This example is not exhaustive. It should initially include the fixed content preferred size and final bounds for the real client components:
+
+- field
+- home sidebar
+- away sidebar
+- score bar
+- log
+- chat
+
+It should include any additional replay/status/menu areas later if they become part of the content layout.
 
 Initially this result can reproduce the current fixed `LANDSCAPE`, `PORTRAIT`, `SQUARE`, and `WIDE` layouts.
 
@@ -142,18 +154,23 @@ The layout pass should take GUI scale into account when calculating non-pitch co
 
 The important shift is that layout becomes data calculated by one component, instead of being implicit in nested Swing panels.
 
-## Phase 6: Make UserInterface Consume The Layout Result
+## Phase 6: Make UserInterface Use The Layout Panel
 
-Refactor `UserInterface.initComponents(...)` so it consumes `ClientLayoutResult`.
+Refactor `UserInterface.initComponents(...)` so it calculates a `ClientLayoutResult` and uses `ClientLayoutPanel` as the fixed content panel.
 
 Initial behavior should remain visually identical:
 
 - same packed window size
 - same component sizes
 - same layout variants
+- same non-resizable behavior
 - same `pack()` behavior
 
+`ClientLayoutPanel` owns applying the calculated bounds to Swing components. `UserInterface` should orchestrate component initialization, layout calculation, adding the content panel to the desktop, and `pack()`.
+
 This creates a bridge from the current fixed model to a dynamic layout pass.
+
+This phase should not yet update `PitchViewport` with bounds, introduce resizing, or rename coordinate methods to `worldToScreen` / `screenToWorld`.
 
 ## Phase 7: Promote Local Mapping To Viewport Transforms
 

--- a/docs/fullscreen-layout-plan.md
+++ b/docs/fullscreen-layout-plan.md
@@ -69,7 +69,7 @@ public class PitchViewport {
 }
 ```
 
-This first API should use current-code terminology and preserve existing behavior. Do not introduce `worldToScreen` / `screenToWorld` yet because the viewport does not own screen bounds at this stage.
+This first API should use current-code terminology and preserve existing behavior. `worldToScreen` / `screenToWorld` terminology comes later, once the viewport owns screen bounds.
 
 At this stage it can still use existing `LayoutSettings`, `ClientLayout`, and fixed component sizes internally. The purpose is to move responsibility first, not change behavior.
 
@@ -99,7 +99,7 @@ Update common `FieldLayer` helpers to use `PitchViewport.toLocal(...)` and `Pitc
 
 Then gradually migrate direct `pitchDimensionProvider.mapToLocal(...)` calls in individual field layers, states, animations, sketches, range rulers, and marker popup placement.
 
-This phase covers rendering and UI placement coordinate mapping. It does not include setup drag/drop input, which is handled separately after layout bounds exist.
+This phase covers rendering and UI placement coordinate mapping. Setup drag/drop input is handled separately after layout bounds exist.
 
 ## Phase 5: Introduce A Layout Result
 
@@ -170,7 +170,7 @@ Initial behavior should remain visually identical:
 
 This creates a bridge from the current fixed model to a dynamic layout pass.
 
-This phase should not yet update `PitchViewport` with bounds, introduce resizing, or rename coordinate methods to `worldToScreen` / `screenToWorld`.
+`PitchViewport` bounds, resizing, and `worldToScreen` / `screenToWorld` terminology remain outside this phase.
 
 ## Phase 7: Promote Local Mapping To Viewport Transforms
 
@@ -179,15 +179,17 @@ After the layout result exists and `PitchViewport` owns the calculated pitch bou
 - `worldToScreen(FieldCoordinate)`
 - `screenToWorld(Point)`
 
-Until then, keep `toLocal(...)` and `toFieldCoordinate(...)` because current methods return field-component-local coordinates.
+Keep `toLocal(...)` and `toFieldCoordinate(...)` as field-component-local methods. They remain correct for rendering and input code whose coordinate parent is the `FieldComponent` or a field layer buffer.
 
-At this point, decide whether to keep the old methods as compatibility wrappers or migrate callers to the new names.
+Use `worldToScreen(...)` and `screenToWorld(...)` for coordinates in the client content / viewport space, where the pitch position inside `ClientLayoutPanel` matters. In this plan, "screen" means the client content coordinate space, not OS/global monitor coordinates.
+
+Caller migration should follow the coordinate space involved. Code that works in client content coordinates can use the viewport transform methods, while field-local rendering can continue to use the local methods.
 
 ## Phase 8: Handle Setup Drag/Drop Coordinate Mapping
 
 Evaluate `UtilClientPlayerDrag` after the layout result exists and `PitchViewport` owns calculated pitch bounds. Setup drag/drop has different edge behavior from `CoordinateConverter`, handles field/box crossing, and can produce reserve/box sentinel coordinates.
 
-Before changing it, add or maintain tests that pin current behavior for:
+The current behavior should be pinned with tests before changing it:
 
 - field edge coordinates
 - portrait conversion

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/CoordinateConverter.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/CoordinateConverter.java
@@ -2,29 +2,16 @@ package com.fumbbl.ffb.client;
 
 import com.fumbbl.ffb.FieldCoordinate;
 
-import java.awt.*;
 import java.awt.event.MouseEvent;
 
 public class CoordinateConverter {
-	private final UiDimensionProvider uiDimensionProvider;
-	private final PitchDimensionProvider pitchDimensionProvider;
+	private final PitchViewport pitchViewport;
 
-	public CoordinateConverter(UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider) {
-		this.uiDimensionProvider = uiDimensionProvider;
-		this.pitchDimensionProvider = pitchDimensionProvider;
+	public CoordinateConverter(PitchViewport pitchViewport) {
+		this.pitchViewport = pitchViewport;
 	}
 
 	public FieldCoordinate getFieldCoordinate(MouseEvent pMouseEvent) {
-		FieldCoordinate coordinate = null;
-		int x = pMouseEvent.getX();
-		int y = pMouseEvent.getY();
-		Dimension field = uiDimensionProvider.dimension(Component.FIELD);
-		if ((x > 0) && (x < field.width) && (y > 0) && (y < field.height)) {
-			coordinate = new FieldCoordinate((int) ((x / (pitchDimensionProvider.getLayoutSettings().getScale() * pitchDimensionProvider.getLayoutSettings().getLayout().getPitchScale())) / pitchDimensionProvider.unscaledFieldSquare()),
-				(int) ((y / (pitchDimensionProvider.getLayoutSettings().getScale() * pitchDimensionProvider.getLayoutSettings().getLayout().getPitchScale())) / pitchDimensionProvider.unscaledFieldSquare()));
-			coordinate = pitchDimensionProvider.mapToGlobal(coordinate);
-		}
-		return coordinate;
+		return pitchViewport.toFieldCoordinate(pMouseEvent.getPoint());
 	}
-
 }

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/FieldComponent.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/FieldComponent.java
@@ -76,23 +76,24 @@ public class FieldComponent extends JPanel implements IModelChangeObserver, Mous
 	private final UiDimensionProvider uiDimensionProvider;
 
 	public FieldComponent(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider,
-												PitchDimensionProvider pitchDimensionProvider, FontCache fontCache,
-												ClientSketchManager sketchManager, StyleProvider styleProvider) {
+												PitchDimensionProvider pitchDimensionProvider, PitchViewport pitchViewport,
+												FontCache fontCache, ClientSketchManager sketchManager,
+												StyleProvider styleProvider) {
 
 		fClient = pClient;
 		this.uiDimensionProvider = uiDimensionProvider;
-		fLayerField = new FieldLayerPitch(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		fLayerTeamLogo = new FieldLayerTeamLogo(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		fLayerBloodspots = new FieldLayerBloodspots(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		fLayerRangeGrid = new FieldLayerRangeGrid(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		fLayerMarker = new FieldLayerMarker(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		fLayerUnderPlayers = new FieldLayerUnderPlayers(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		fLayerPlayers = new FieldLayerPlayers(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		fLayerOverPlayers = new FieldLayerOverPlayers(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		fLayerRangeRuler = new FieldLayerRangeRuler(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		layerEnhancements = new FieldLayerEnhancements(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
-		layerSketches = new FieldLayerSketches(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache, sketchManager);
-		layerTackleZones = new FieldLayerTackleZones(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache, styleProvider);
+		fLayerField = new FieldLayerPitch(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		fLayerTeamLogo = new FieldLayerTeamLogo(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		fLayerBloodspots = new FieldLayerBloodspots(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		fLayerRangeGrid = new FieldLayerRangeGrid(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		fLayerMarker = new FieldLayerMarker(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		fLayerUnderPlayers = new FieldLayerUnderPlayers(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		fLayerPlayers = new FieldLayerPlayers(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		fLayerOverPlayers = new FieldLayerOverPlayers(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		fLayerRangeRuler = new FieldLayerRangeRuler(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		layerEnhancements = new FieldLayerEnhancements(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
+		layerSketches = new FieldLayerSketches(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache, sketchManager);
+		layerTackleZones = new FieldLayerTackleZones(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache, styleProvider);
 
 		fCoordinateByPlayerId = new HashMap<>();
 

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
@@ -24,6 +24,10 @@ public class PitchViewport {
 		return pitchDimensionProvider.fieldSquareSize();
 	}
 
+	public int squareSize(double factor) {
+		return pitchDimensionProvider.fieldSquareSize(factor);
+	}
+
 	public int imageOffset() {
 		return pitchDimensionProvider.imageOffset();
 	}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
@@ -47,6 +47,19 @@ public class PitchViewport {
 		return pitchDimensionProvider.mapToLocal(x, y, center);
 	}
 
+	public Point worldToScreen(FieldCoordinate coordinate) {
+		return worldToScreen(coordinate, false);
+	}
+
+	public Point worldToScreen(FieldCoordinate coordinate, boolean center) {
+		return worldToScreen(coordinate.getX(), coordinate.getY(), center);
+	}
+
+	public Point worldToScreen(int x, int y, boolean center) {
+		Dimension local = toLocal(x, y, center);
+		return new Point(viewportBounds.x + local.width, viewportBounds.y + local.height);
+	}
+
 	public FieldCoordinate toFieldCoordinate(Point localPoint) {
 		FieldCoordinate coordinate = null;
 		int x = localPoint.x;
@@ -65,6 +78,12 @@ public class PitchViewport {
 		}
 
 		return coordinate;
+	}
+
+	// Screen coordinates are currently client content coordinates, not OS/global monitor coordinates.
+	public FieldCoordinate screenToWorld(Point screenPoint) {
+		Point localPoint = new Point(screenPoint.x - viewportBounds.x, screenPoint.y - viewportBounds.y);
+		return toFieldCoordinate(localPoint);
 	}
 
 	public Direction toLocal(Direction direction) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
@@ -40,7 +40,6 @@ public class PitchViewport {
 		return pitchDimensionProvider.mapToLocal(x, y, center);
 	}
 
-  // From CoordinateConverter
 	public FieldCoordinate toFieldCoordinate(Point localPoint) {
 		FieldCoordinate coordinate = null;
 		int x = localPoint.x;

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
@@ -1,0 +1,71 @@
+package com.fumbbl.ffb.client;
+
+import com.fumbbl.ffb.Direction;
+import com.fumbbl.ffb.FieldCoordinate;
+
+import java.awt.Dimension;
+import java.awt.Point;
+
+public class PitchViewport {
+
+	private final UiDimensionProvider uiDimensionProvider;
+	private final PitchDimensionProvider pitchDimensionProvider;
+
+	public PitchViewport(UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider) {
+		this.uiDimensionProvider = uiDimensionProvider;
+		this.pitchDimensionProvider = pitchDimensionProvider;
+	}
+
+	public Dimension fieldSize() {
+		return uiDimensionProvider.dimension(Component.FIELD);
+	}
+
+	public int squareSize() {
+		return pitchDimensionProvider.fieldSquareSize();
+	}
+
+	public int imageOffset() {
+		return pitchDimensionProvider.imageOffset();
+	}
+
+	public Dimension toLocal(FieldCoordinate coordinate) {
+		return pitchDimensionProvider.mapToLocal(coordinate);
+	}
+
+	public Dimension toLocal(FieldCoordinate coordinate, boolean center) {
+		return pitchDimensionProvider.mapToLocal(coordinate, center);
+	}
+
+	public Dimension toLocal(int x, int y, boolean center) {
+		return pitchDimensionProvider.mapToLocal(x, y, center);
+	}
+
+  // From CoordinateConverter
+	public FieldCoordinate toFieldCoordinate(Point localPoint) {
+		FieldCoordinate coordinate = null;
+		int x = localPoint.x;
+		int y = localPoint.y;
+		Dimension field = fieldSize();
+
+		if ((x > 0) && (x < field.width) && (y > 0) && (y < field.height)) {
+			double scale = pitchDimensionProvider.getLayoutSettings().getScale()
+				* pitchDimensionProvider.getLayoutSettings().getLayout().getPitchScale();
+
+			coordinate = new FieldCoordinate(
+				(int) ((x / scale) / pitchDimensionProvider.unscaledFieldSquare()),
+				(int) ((y / scale) / pitchDimensionProvider.unscaledFieldSquare())
+			);
+			coordinate = pitchDimensionProvider.mapToGlobal(coordinate);
+		}
+
+		return coordinate;
+	}
+
+	public Direction toLocal(Direction direction) {
+		return pitchDimensionProvider.mapToLocal(direction);
+	}
+
+	public Direction getLocalDirection(FieldCoordinate from, FieldCoordinate to) {
+		return pitchDimensionProvider.getDirection(from, to);
+	}
+}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/PitchViewport.java
@@ -5,15 +5,18 @@ import com.fumbbl.ffb.FieldCoordinate;
 
 import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.Rectangle;
 
 public class PitchViewport {
 
 	private final UiDimensionProvider uiDimensionProvider;
 	private final PitchDimensionProvider pitchDimensionProvider;
+	private Rectangle viewportBounds;
 
 	public PitchViewport(UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider) {
 		this.uiDimensionProvider = uiDimensionProvider;
 		this.pitchDimensionProvider = pitchDimensionProvider;
+		this.viewportBounds = new Rectangle(0, 0, fieldSize().width, fieldSize().height);
 	}
 
 	public Dimension fieldSize() {
@@ -70,5 +73,13 @@ public class PitchViewport {
 
 	public Direction getLocalDirection(FieldCoordinate from, FieldCoordinate to) {
 		return pitchDimensionProvider.getDirection(from, to);
+	}
+
+	public Rectangle viewportBounds() {
+		return new Rectangle(viewportBounds);
+	}
+
+	public void setViewportBounds(Rectangle viewportBounds) {
+		this.viewportBounds = new Rectangle(viewportBounds);
 	}
 }

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
@@ -146,7 +146,7 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 		fScoreBar.initLayout();
 
 		ClientLayoutResult layoutResult = layoutCalculator.calculate(uiDimensionProvider);
-
+		pitchViewport.setViewportBounds(layoutResult.fieldBounds());
 		if (layoutPanel.getParent() != null) {
 			layoutPanel.getParent().remove(layoutPanel);
 		}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
@@ -66,6 +66,7 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 	private final CoordinateConverter coordinateConverter;
 	private final ClientSketchManager sketchManager;
 	private final MarkerService markerService;
+	private final PitchViewport pitchViewport;
 
 
 	public UserInterface(FantasyFootballClient pClient) {
@@ -85,7 +86,8 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 		layoutSettings = new LayoutSettings(pClient.getParameters().getLayout(), scale);
 		uiDimensionProvider = new UiDimensionProvider(layoutSettings);
 		pitchDimensionProvider = new PitchDimensionProvider(layoutSettings);
-		coordinateConverter = new CoordinateConverter(uiDimensionProvider, pitchDimensionProvider);
+		pitchViewport = new PitchViewport(uiDimensionProvider, pitchDimensionProvider);
+		coordinateConverter = new CoordinateConverter(pitchViewport);
 		sketchManager = new ClientSketchManager(pClient.getParameters().getCoach(), pitchDimensionProvider);
 		dugoutDimensionProvider = new DugoutDimensionProvider(layoutSettings);
 		fIconCache = new IconCache(getClient());
@@ -301,6 +303,10 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 
 	public GameTitle getGameTitle() {
 		return fGameTitle;
+	}
+
+	public PitchViewport getPitchViewport() {
+		return pitchViewport;
 	}
 
 	public void setGameTitle(GameTitle pGameTitle) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
@@ -111,7 +111,8 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 		setResizable(false);
 
 		fScoreBar = new ScoreBarComponent(getClient(), uiDimensionProvider, styleProvider, fontCache);
-		fFieldComponent = new FieldComponent(getClient(), uiDimensionProvider, pitchDimensionProvider, fontCache, sketchManager, styleProvider);
+		fFieldComponent = new FieldComponent(getClient(), uiDimensionProvider, pitchDimensionProvider, pitchViewport,
+			fontCache, sketchManager, styleProvider);
 		fLog = new LogComponent(getClient(), styleProvider, uiDimensionProvider);
 		fChat = new ChatComponent(getClient(), uiDimensionProvider, styleProvider, fIconCache);
 		fSideBarHome = new SideBarComponent(getClient(), true, uiDimensionProvider, dugoutDimensionProvider, styleProvider, fontCache, markerService);

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
@@ -88,7 +88,7 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 		pitchDimensionProvider = new PitchDimensionProvider(layoutSettings);
 		pitchViewport = new PitchViewport(uiDimensionProvider, pitchDimensionProvider);
 		coordinateConverter = new CoordinateConverter(pitchViewport);
-		sketchManager = new ClientSketchManager(pClient.getParameters().getCoach(), pitchDimensionProvider);
+		sketchManager = new ClientSketchManager(pClient.getParameters().getCoach(), pitchDimensionProvider, pitchViewport);
 		dugoutDimensionProvider = new DugoutDimensionProvider(layoutSettings);
 		fIconCache = new IconCache(getClient());
 		fIconCache.init();

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
@@ -9,6 +9,9 @@ import com.fumbbl.ffb.client.dialog.DialogLeaveGame;
 import com.fumbbl.ffb.client.dialog.DialogManager;
 import com.fumbbl.ffb.client.dialog.IDialog;
 import com.fumbbl.ffb.client.dialog.IDialogCloseListener;
+import com.fumbbl.ffb.client.layout.ClientLayoutCalculator;
+import com.fumbbl.ffb.client.layout.ClientLayoutPanel;
+import com.fumbbl.ffb.client.layout.ClientLayoutResult;
 import com.fumbbl.ffb.client.overlay.sketch.ClientSketchManager;
 import com.fumbbl.ffb.client.sound.SoundEngine;
 import com.fumbbl.ffb.client.state.ClientState;
@@ -67,6 +70,8 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 	private final ClientSketchManager sketchManager;
 	private final MarkerService markerService;
 	private final PitchViewport pitchViewport;
+	private final ClientLayoutCalculator layoutCalculator;
+	private final ClientLayoutPanel layoutPanel;
 
 
 	public UserInterface(FantasyFootballClient pClient) {
@@ -104,6 +109,7 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 		fPlayerIconFactory = new PlayerIconFactory();
 		fStatusReport = new StatusReport(getClient());
 		fMouseEntropySource = new MouseEntropySource(this);
+		layoutCalculator = new ClientLayoutCalculator();
 
 
 		setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
@@ -117,6 +123,7 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 		fChat = new ChatComponent(getClient(), uiDimensionProvider, styleProvider, fIconCache);
 		fSideBarHome = new SideBarComponent(getClient(), true, uiDimensionProvider, dugoutDimensionProvider, styleProvider, fontCache, markerService);
 		fSideBarAway = new SideBarComponent(getClient(), false, uiDimensionProvider, dugoutDimensionProvider, styleProvider, fontCache, markerService);
+		layoutPanel = new ClientLayoutPanel(fFieldComponent, fSideBarHome, fSideBarAway, fScoreBar, fLog, fChat);
 
 		initComponents(false);
 
@@ -138,23 +145,15 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 		fSideBarAway.initLayout();
 		fScoreBar.initLayout();
 
-		JPanel panelContent;
-		switch (layoutSettings.getLayout()) {
-			case PORTRAIT:
-				panelContent = portraitContent();
-				break;
-			case SQUARE:
-				panelContent = squareContent();
-				break;
-			default:
-				panelContent = landscapeContent();
-				break;
+		ClientLayoutResult layoutResult = layoutCalculator.calculate(uiDimensionProvider);
+
+		if (layoutPanel.getParent() != null) {
+			layoutPanel.getParent().remove(layoutPanel);
 		}
+		layoutPanel.apply(layoutResult);
 
-		panelContent.setSize(panelContent.getPreferredSize());
-
-		fDesktop.add(panelContent, -1);
-		fDesktop.setPreferredSize(panelContent.getPreferredSize());
+		fDesktop.add(layoutPanel, -1);
+		fDesktop.setPreferredSize(layoutResult.preferredSize());
 
 		getContentPane().add(fDesktop, BorderLayout.CENTER);
 		pack();
@@ -170,76 +169,6 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 		}
 		fDialogManager.setShownDialogParameter(null);
 		fDialogManager.updateDialog();
-	}
-
-	private JPanel landscapeContent() {
-		JPanel fieldPanel = fieldPanel();
-
-		JPanel logChatPanel = logChatPanel();
-
-		JPanel panelCenter = wrapperPanel(BoxLayout.Y_AXIS, fieldPanel, getScoreBar(), logChatPanel);
-
-		return wrapperPanel(BoxLayout.X_AXIS, createSideBarPanel(fSideBarHome), panelCenter, createSideBarPanel(fSideBarAway));
-	}
-
-	private JPanel createSideBarPanel(SideBarComponent fSideBarHome) {
-		JPanel panelHome = new JPanel();
-		panelHome.setLayout(new BoxLayout(panelHome, BoxLayout.Y_AXIS));
-		panelHome.add(fSideBarHome);
-		return panelHome;
-	}
-
-	private JPanel portraitContent() {
-		JPanel fieldPanel = fieldPanel();
-
-		JPanel logChatPanel = logChatPanel();
-
-		JPanel panelMain = wrapperPanel(BoxLayout.X_AXIS, createSideBarPanel(fSideBarHome), fieldPanel, createSideBarPanel(fSideBarAway));
-
-		return wrapperPanel(BoxLayout.Y_AXIS, panelMain, getScoreBar(), logChatPanel);
-	}
-
-	private JPanel logChatPanel() {
-		JPanel logChatPanel = new JPanel();
-		logChatPanel.setLayout(new BoxLayout(logChatPanel, BoxLayout.X_AXIS));
-		logChatPanel.add(getLog());
-		logChatPanel.add(Box.createHorizontalStrut(2));
-		logChatPanel.add(getChat());
-		logChatPanel.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
-		return logChatPanel;
-	}
-
-	private JPanel fieldPanel() {
-		JPanel fieldPanel = new JPanel();
-		fieldPanel.setLayout(new BoxLayout(fieldPanel, BoxLayout.X_AXIS));
-		fieldPanel.add(fFieldComponent);
-		return fieldPanel;
-	}
-
-	private JPanel squareContent() {
-		JPanel fieldPanel = fieldPanel();
-
-		JPanel logChatScorePanel = wrapperPanel(BoxLayout.Y_AXIS, getLog(), getScoreBar(), getChat());
-		logChatScorePanel.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
-
-		JPanel panelMain = wrapperPanel(BoxLayout.X_AXIS, createSideBarPanel(fSideBarHome), fieldPanel, createSideBarPanel(fSideBarAway));
-
-		JPanel panelContent = new JPanel();
-		panelContent.setLayout(new BoxLayout(panelContent, BoxLayout.X_AXIS));
-		panelContent.add(panelMain);
-		panelContent.add(logChatScorePanel);
-
-		return panelContent;
-	}
-
-	private JPanel wrapperPanel(int axis, JPanel fSideBarHome, JPanel fieldPanel, JPanel fSideBarAway) {
-		JPanel panelMain = new JPanel();
-		//noinspection MagicConstant
-		panelMain.setLayout(new BoxLayout(panelMain, axis));
-		panelMain.add(fSideBarHome);
-		panelMain.add(fieldPanel);
-		panelMain.add(fSideBarAway);
-		return panelMain;
 	}
 
 	public ClientSketchManager getSketchManager() {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationProjector.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationProjector.java
@@ -1,7 +1,7 @@
 package com.fumbbl.ffb.client.animation;
 
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.client.PitchDimensionProvider;
+import com.fumbbl.ffb.client.PitchViewport;
 import com.fumbbl.ffb.model.AnimationType;
 
 import java.awt.*;
@@ -18,16 +18,16 @@ public class AnimationProjector {
 	private double currentHeight;
 
 	public AnimationProjector(FieldCoordinate start, FieldCoordinate end, FieldCoordinate interceptor,
-							  PitchDimensionProvider dimensionProvider, SteppingStrategy steppingStrategy) {
+							   PitchViewport pitchViewport, SteppingStrategy steppingStrategy) {
 		stepping = steppingStrategy.findStepping();
 
-		startDimension = dimensionProvider.mapToLocal(start, true);
-		endDimension = dimensionProvider.mapToLocal(end, true);
+		startDimension = pitchViewport.toLocal(start, true);
+		endDimension = pitchViewport.toLocal(end, true);
 		xAxisAnimation = (Math.abs(endDimension.width - startDimension.width) > Math.abs(endDimension.height - startDimension.height));
 		interceptorDimension = new Dimension(endDimension);
 
 		if (interceptor != null) {
-			interceptorDimension = dimensionProvider.mapToLocal(interceptor, true);
+			interceptorDimension = pitchViewport.toLocal(interceptor, true);
 		}
 
 		currentWidth = startDimension.getWidth();

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationSequenceChained.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationSequenceChained.java
@@ -23,12 +23,13 @@ public class AnimationSequenceChained implements IAnimationSequence, ActionListe
 
 	public static AnimationSequenceChained createAnimationSequenceTrickster(FantasyFootballClient client, Animation animation) {
 		PitchDimensionProvider dimensionProvider = client.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = client.getUserInterface().getPitchViewport();
 		PlayerIconFactory playerIconFactory = client.getUserInterface().getPlayerIconFactory();
 		Player<?> player = client.getGame().getPlayerById(animation.getThrownPlayerId());
 		BufferedImage icon = playerIconFactory.getIcon(client, player, dimensionProvider);
 
 		return new AnimationSequenceChained(
-			new AnimationData(dimensionProvider.mapToLocal(animation.getStartCoordinate(), true),
+			new AnimationData(pitchViewport.toLocal(animation.getStartCoordinate(), true),
 				new AnimationFrame[]{
 					new AnimationFrame(IIconProperty.ANIMATION_TRICKSTER_GLOW_1, 0.8f, 1.0d, icon, 1.0f, 1.0d,120, SoundId.HYPNO),
 					new AnimationFrame(IIconProperty.ANIMATION_TRICKSTER_GLOW_2, 0.6f, 1.0d, icon, 0.9f, 0.95d,120),
@@ -39,7 +40,7 @@ public class AnimationSequenceChained implements IAnimationSequence, ActionListe
 					new AnimationFrame(IIconProperty.ANIMATION_TRICKSTER_SMOKE_3, 0.7f, 0.35d, icon, 0.2f, 0.2d,120),
 					new AnimationFrame(IIconProperty.ANIMATION_TRICKSTER_SMOKE_4, 0.5f, 0.35d, icon, 0.0f, 0.05d,120),
 				}),
-			new AnimationData(dimensionProvider.mapToLocal(animation.getEndCoordinate(), true),
+			new AnimationData(pitchViewport.toLocal(animation.getEndCoordinate(), true),
 				new AnimationFrame[]{
 					new AnimationFrame(IIconProperty.ANIMATION_TRICKSTER_EXPLOSION_1, 0.8f, 0.6d, 120, SoundId.BLUNDER),
 					new AnimationFrame(IIconProperty.ANIMATION_TRICKSTER_EXPLOSION_2, 0.6f, 0.6d, icon, 0.2f, 0.2d,120),
@@ -64,16 +65,16 @@ public class AnimationSequenceChained implements IAnimationSequence, ActionListe
 
 
 	public static AnimationSequenceChained createAnimationSequenceBlastin(FantasyFootballClient client, Animation animation) {
-		PitchDimensionProvider dimensionProvider = client.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = client.getUserInterface().getPitchViewport();
 
 		return new AnimationSequenceChained(
-			new AnimationData(dimensionProvider.mapToLocal(animation.getStartCoordinate(), true),
+			new AnimationData(pitchViewport.toLocal(animation.getStartCoordinate(), true),
 				new AnimationFrame[]{
 					new AnimationFrame(IIconProperty.ANIMATION_BLASTIN_EXPLOSION_1, 0.8f, 0.5d, 60, SoundId.BLUNDER),
 					new AnimationFrame(IIconProperty.ANIMATION_BLASTIN_SMOKE_1, 1.0f, 0.35d, 60),
 					new AnimationFrame(IIconProperty.ANIMATION_BLASTIN_SMOKE_2, 1.0f, 0.15d,60),
 				}),
-			new AnimationData(dimensionProvider.mapToLocal(animation.getEndCoordinate(), true),
+			new AnimationData(pitchViewport.toLocal(animation.getEndCoordinate(), true),
 				new AnimationFrame[]{
 					new AnimationFrame(IIconProperty.ANIMATION_BLASTIN_EXPLOSION_1, 0.8f, 0.6d,  120, SoundId.EXPLODE),
 					new AnimationFrame(IIconProperty.ANIMATION_BLASTIN_EXPLOSION_2, 0.6f, 0.6d, 120),

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationSequenceFactory.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationSequenceFactory.java
@@ -5,6 +5,7 @@ import com.fumbbl.ffb.client.Component;
 import com.fumbbl.ffb.client.DimensionProvider;
 import com.fumbbl.ffb.client.FantasyFootballClient;
 import com.fumbbl.ffb.client.PitchDimensionProvider;
+import com.fumbbl.ffb.client.PitchViewport;
 import com.fumbbl.ffb.model.Animation;
 
 import java.awt.*;
@@ -138,7 +139,8 @@ public class AnimationSequenceFactory {
 			case PRAYER_BLESSED_STATUE_OF_NUFFLE:
 				return AnimationSequenceKickoff.createAnimationSequence(fieldDimension, IIconProperty.ANIMATION_PRAYER_BLESSED_STATUE_OF_NUFFLE, dimensionProvider.isPitchPortrait());
 			case BREATHE_FIRE:
-				return AnimationSequenceMovingEffect.createAnimationSequenceBreatheFire(pAnimation.getStartCoordinate(), pAnimation.getEndCoordinate(), dimensionProvider);
+				PitchViewport pitchViewport = pClient.getUserInterface().getPitchViewport();
+				return AnimationSequenceMovingEffect.createAnimationSequenceBreatheFire(pAnimation.getStartCoordinate(), pAnimation.getEndCoordinate(), dimensionProvider, pitchViewport);
 			case PRAYER_DAZZLING_CATCHING:
 				return AnimationSequenceKickoff.createAnimationSequence(fieldDimension, IIconProperty.ANIMATION_PRAYER_DAZZLING_CATCHING, dimensionProvider.isPitchPortrait());
 			default:

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationSequenceMovingEffect.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationSequenceMovingEffect.java
@@ -2,6 +2,7 @@ package com.fumbbl.ffb.client.animation;
 
 import com.fumbbl.ffb.*;
 import com.fumbbl.ffb.client.PitchDimensionProvider;
+import com.fumbbl.ffb.client.PitchViewport;
 import com.fumbbl.ffb.client.layer.FieldLayer;
 import com.fumbbl.ffb.client.sound.SoundEngine;
 
@@ -12,8 +13,9 @@ import java.util.Arrays;
 
 public class AnimationSequenceMovingEffect implements IAnimationSequence, ActionListener {
 
-  public static AnimationSequenceMovingEffect createAnimationSequenceBreatheFire(FieldCoordinate start, FieldCoordinate end, PitchDimensionProvider dimensionProvider) {
-    return new AnimationSequenceMovingEffect(start, end, dimensionProvider, 1000, new AnimationFrame[]{
+  public static AnimationSequenceMovingEffect createAnimationSequenceBreatheFire(FieldCoordinate start,
+      FieldCoordinate end, PitchDimensionProvider dimensionProvider, PitchViewport pitchViewport) {
+    return new AnimationSequenceMovingEffect(start, end, dimensionProvider, pitchViewport, 1000, new AnimationFrame[]{
       new AnimationFrame(IIconProperty.ANIMATION_FIREBALL_EXPLOSION_1, 1.0f, 500, SoundId.FIREBALL),
       new AnimationFrame(IIconProperty.ANIMATION_FIREBALL_EXPLOSION_2, 1.0f, 500),
       new AnimationFrame(IIconProperty.ANIMATION_FIREBALL_EXPLOSION_3, 1.0f, 500),
@@ -47,15 +49,16 @@ public class AnimationSequenceMovingEffect implements IAnimationSequence, Action
   private IAnimationListener fListener;
 
   protected AnimationSequenceMovingEffect(FieldCoordinate pStartCoordinate, FieldCoordinate pEndCoordinate,
-                                          PitchDimensionProvider dimensionProvider, long duration, AnimationFrame[] frames) {
+                                          PitchDimensionProvider dimensionProvider, PitchViewport pitchViewport,
+                                          long duration, AnimationFrame[] frames) {
     timerDelay = (int) (20 / (dimensionProvider.getLayoutSettings().getScale() * dimensionProvider.getLayoutSettings().getLayout().getPitchScale()));
     fTimer = new Timer(timerDelay, this);
     this.frames = frames;
     this.duration = duration;
     this.totalDurationWeight = Arrays.stream(frames).mapToLong(AnimationFrame::getTime).sum();
-    this.animationProjector = new AnimationProjector(pStartCoordinate, pEndCoordinate, null, dimensionProvider,
-      new TimerBasedSteppingStrategy(dimensionProvider.mapToLocal(pStartCoordinate),
-        dimensionProvider.mapToLocal(pEndCoordinate), duration, timerDelay));
+    this.animationProjector = new AnimationProjector(pStartCoordinate, pEndCoordinate, null, pitchViewport,
+      new TimerBasedSteppingStrategy(pitchViewport.toLocal(pStartCoordinate),
+        pitchViewport.toLocal(pEndCoordinate), duration, timerDelay));
   }
 
   public void play(FieldLayer pFieldLayer, IAnimationListener pListener) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationSequenceThrowing.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/animation/AnimationSequenceThrowing.java
@@ -25,57 +25,62 @@ public class AnimationSequenceThrowing implements IAnimationSequence, ActionList
 
 	protected AnimationSequenceThrowing(AnimationType pAnimationType, BufferedImage pAnimatedIcon,
 																			FieldCoordinate pStartCoordinate, FieldCoordinate pEndCoordinate, FieldCoordinate pInterceptorCoordinate,
-																			SoundId pSound, PitchDimensionProvider dimensionProvider) {
+																			SoundId pSound, PitchDimensionProvider dimensionProvider, PitchViewport pitchViewport) {
 		fAnimationType = pAnimationType;
 		fAnimatedIcon = pAnimatedIcon;
 		fSound = pSound;
 		fTimer = new Timer((int) (20 / (dimensionProvider.getLayoutSettings().getScale() * dimensionProvider.getLayoutSettings().getLayout().getPitchScale())), this);
-		this.animationProjector = new AnimationProjector(pStartCoordinate, pEndCoordinate, pInterceptorCoordinate, dimensionProvider,
+		this.animationProjector = new AnimationProjector(pStartCoordinate, pEndCoordinate, pInterceptorCoordinate, pitchViewport,
 			new CoordinateBasedSteppingStrategy(pStartCoordinate, pEndCoordinate));
 	}
 
 	public static AnimationSequenceThrowing createAnimationSequencePass(FantasyFootballClient pClient, Animation pAnimation) {
-		PitchDimensionProvider dimensionProvider = pClient.getUserInterface().getPitchDimensionProvider(); 
+		PitchDimensionProvider dimensionProvider = pClient.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = pClient.getUserInterface().getPitchViewport();
 		return new AnimationSequenceThrowing(AnimationType.PASS,
 			pClient.getUserInterface().getIconCache().getIconByProperty(IIconProperty.GAME_BALL, dimensionProvider),
 			pAnimation.getStartCoordinate(), pAnimation.getEndCoordinate(), pAnimation.getInterceptorCoordinate(),
-			SoundId.THROW, dimensionProvider);
+			SoundId.THROW, dimensionProvider, pitchViewport);
 	}
 
 	public static AnimationSequenceThrowing createAnimationSequenceThrowBomb(FantasyFootballClient pClient,
 			Animation pAnimation) {
 		PitchDimensionProvider dimensionProvider = pClient.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = pClient.getUserInterface().getPitchViewport();
 		return new AnimationSequenceThrowing(AnimationType.THROW_BOMB,
 			pClient.getUserInterface().getIconCache().getIconByProperty(IIconProperty.GAME_BOMB, dimensionProvider),
 			pAnimation.getStartCoordinate(), pAnimation.getEndCoordinate(), pAnimation.getInterceptorCoordinate(),
-			SoundId.THROW, dimensionProvider);
+			SoundId.THROW, dimensionProvider, pitchViewport);
 	}
 
 	public static AnimationSequenceThrowing createAnimationSequenceThrowARock(FantasyFootballClient pClient,
 			Animation pAnimation) {
 		PitchDimensionProvider dimensionProvider = pClient.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = pClient.getUserInterface().getPitchViewport();
 		return new AnimationSequenceThrowing(AnimationType.THROW_A_ROCK,
 			pClient.getUserInterface().getIconCache().getIconByProperty(IIconProperty.GAME_ROCK, dimensionProvider),
 			pAnimation.getStartCoordinate(), pAnimation.getEndCoordinate(), pAnimation.getInterceptorCoordinate(),
-			SoundId.THROW, dimensionProvider);
+			SoundId.THROW, dimensionProvider, pitchViewport);
 	}
 
 	public static AnimationSequenceThrowing createAnimationSequenceKick(FantasyFootballClient pClient, Animation pAnimation) {
 		PitchDimensionProvider dimensionProvider = pClient.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = pClient.getUserInterface().getPitchViewport();
 		return new AnimationSequenceThrowing(AnimationType.KICK,
 			pClient.getUserInterface().getIconCache().getIconByProperty(IIconProperty.GAME_BALL_BIG, dimensionProvider),
 			pAnimation.getStartCoordinate(), pAnimation.getEndCoordinate(), pAnimation.getInterceptorCoordinate(),
-			SoundId.KICK, dimensionProvider);
+			SoundId.KICK, dimensionProvider, pitchViewport);
 	}
 
 	private final AnimationType fAnimationType;
 
 	public static AnimationSequenceThrowing createAnimationSequenceHailMaryPass(FantasyFootballClient pClient, Animation pAnimation) {
 		PitchDimensionProvider dimensionProvider = pClient.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = pClient.getUserInterface().getPitchViewport();
 		return new AnimationSequenceThrowing(AnimationType.HAIL_MARY_PASS,
 			pClient.getUserInterface().getIconCache().getIconByProperty(IIconProperty.GAME_BALL_BIG, dimensionProvider),
 			pAnimation.getStartCoordinate(), pAnimation.getEndCoordinate(), pAnimation.getInterceptorCoordinate(),
-			SoundId.THROW, dimensionProvider);
+			SoundId.THROW, dimensionProvider, pitchViewport);
 	}
 
 	private final BufferedImage fAnimatedIcon;
@@ -91,10 +96,11 @@ public class AnimationSequenceThrowing implements IAnimationSequence, ActionList
 
 	public static AnimationSequenceThrowing createAnimationSequenceHailMaryBomb(FantasyFootballClient pClient, Animation pAnimation) {
 		PitchDimensionProvider dimensionProvider = pClient.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = pClient.getUserInterface().getPitchViewport();
 		return new AnimationSequenceThrowing(AnimationType.HAIL_MARY_BOMB,
 			pClient.getUserInterface().getIconCache().getIconByProperty(IIconProperty.GAME_BOMB_BIG, dimensionProvider),
 			pAnimation.getStartCoordinate(), pAnimation.getEndCoordinate(), pAnimation.getInterceptorCoordinate(),
-			SoundId.THROW, dimensionProvider);
+			SoundId.THROW, dimensionProvider, pitchViewport);
 	}
 
 	public static AnimationSequenceThrowing createAnimationSequenceThrowTeamMate(FantasyFootballClient pClient, Animation pAnimation) {
@@ -102,18 +108,20 @@ public class AnimationSequenceThrowing implements IAnimationSequence, ActionList
 		boolean homePlayer = pClient.getGame().getTeamHome().hasPlayer(thrownPlayer);
 		PlayerIconFactory playerIconFactory = pClient.getUserInterface().getPlayerIconFactory();
 		PitchDimensionProvider dimensionProvider = pClient.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = pClient.getUserInterface().getPitchViewport();
 		BufferedImage playerIcon = playerIconFactory.getBasicIcon(pClient, thrownPlayer, homePlayer, false,
 			pAnimation.isWithBall(), false, dimensionProvider);
 		return new AnimationSequenceThrowing(AnimationType.THROW_TEAM_MATE, playerIcon, pAnimation.getStartCoordinate(),
-			pAnimation.getEndCoordinate(), null, SoundId.WOOOAAAH, dimensionProvider);
+			pAnimation.getEndCoordinate(), null, SoundId.WOOOAAAH, dimensionProvider, pitchViewport);
 	}
 
 	public static AnimationSequenceThrowing createAnimationSequenceThrowKeg(FantasyFootballClient pClient, Animation pAnimation) {
 		PitchDimensionProvider dimensionProvider = pClient.getUserInterface().getPitchDimensionProvider();
+		PitchViewport pitchViewport = pClient.getUserInterface().getPitchViewport();
 		return new AnimationSequenceThrowing(pAnimation.getAnimationType(),
 			pClient.getUserInterface().getIconCache().getIconByProperty(IIconProperty.ACTION_BEER_BARREL_BASH, dimensionProvider),
 			pAnimation.getStartCoordinate(), pAnimation.getEndCoordinate(), pAnimation.getInterceptorCoordinate(),
-			SoundId.THROW, dimensionProvider);
+			SoundId.THROW, dimensionProvider, pitchViewport);
 	}
 
 	public void play(FieldLayer pFieldLayer, IAnimationListener pListener) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogPlayerChoice.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogPlayerChoice.java
@@ -3,6 +3,7 @@ package com.fumbbl.ffb.client.dialog;
 import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.client.Component;
 import com.fumbbl.ffb.client.FantasyFootballClient;
+import com.fumbbl.ffb.client.PitchViewport;
 import com.fumbbl.ffb.client.ui.swing.JButton;
 import com.fumbbl.ffb.client.ui.swing.JLabel;
 import com.fumbbl.ffb.dialog.DialogId;
@@ -103,7 +104,8 @@ public class DialogPlayerChoice extends Dialog implements ActionListener {
 			}
 
 			Dimension sidebarSize = getClient().getUserInterface().getUiDimensionProvider().dimension(Component.SIDEBAR);
-			Dimension onPitch = dimensionProvider().mapToLocal(playerCoordinate.getX() + offsetX, playerCoordinate.getY() + offsetY, false);
+			PitchViewport pitchViewport = getClient().getUserInterface().getPitchViewport();
+			Dimension onPitch = pitchViewport.toLocal(playerCoordinate.getX() + offsetX, playerCoordinate.getY() + offsetY, false);
 			int x = sidebarSize.width + onPitch.width;
 			int y = onPitch.height;
 			setLocation(x, y);

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogPlayerChoice.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogPlayerChoice.java
@@ -1,7 +1,6 @@
 package com.fumbbl.ffb.client.dialog;
 
 import com.fumbbl.ffb.FieldCoordinate;
-import com.fumbbl.ffb.client.Component;
 import com.fumbbl.ffb.client.FantasyFootballClient;
 import com.fumbbl.ffb.client.PitchViewport;
 import com.fumbbl.ffb.client.ui.swing.JButton;
@@ -103,12 +102,9 @@ public class DialogPlayerChoice extends Dialog implements ActionListener {
 				offsetX = -1;
 			}
 
-			Dimension sidebarSize = getClient().getUserInterface().getUiDimensionProvider().dimension(Component.SIDEBAR);
 			PitchViewport pitchViewport = getClient().getUserInterface().getPitchViewport();
-			Dimension onPitch = pitchViewport.toLocal(playerCoordinate.getX() + offsetX, playerCoordinate.getY() + offsetY, false);
-			int x = sidebarSize.width + onPitch.width;
-			int y = onPitch.height;
-			setLocation(x, y);
+			Point onPitch = pitchViewport.worldToScreen(playerCoordinate.getX() + offsetX, playerCoordinate.getY() + offsetY, false);
+			setLocation(onPitch.x, onPitch.y);
 		} else {
 			setLocationToCenter();
 		}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayer.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayer.java
@@ -25,13 +25,17 @@ public abstract class FieldLayer {
 
 	protected final UiDimensionProvider uiDimensionProvider;
 	protected final PitchDimensionProvider pitchDimensionProvider;
+	protected final PitchViewport pitchViewport;
 
 	protected final FontCache fontCache;
 
-	public FieldLayer(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
+	public FieldLayer(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider,
+										PitchDimensionProvider pitchDimensionProvider, PitchViewport pitchViewport,
+										FontCache fontCache) {
 		fClient = pClient;
 		this.uiDimensionProvider = uiDimensionProvider;
 		this.pitchDimensionProvider = pitchDimensionProvider;
+		this.pitchViewport = pitchViewport;
 		this.fontCache = fontCache;
 	}
 
@@ -114,12 +118,12 @@ public abstract class FieldLayer {
 	}
 
 	protected int findCenteredIconUpperLeftX(BufferedImage pImage, FieldCoordinate pCoordinate) {
-		Dimension dimension = pitchDimensionProvider.mapToLocal(pCoordinate, true);
+		Dimension dimension = pitchViewport.toLocal(pCoordinate, true);
 		return dimension.width - (pImage.getWidth() / 2);
 	}
 
 	protected int findCenteredIconUpperLeftY(BufferedImage pImage, FieldCoordinate pCoordinate) {
-		Dimension dimension = pitchDimensionProvider.mapToLocal(pCoordinate, true);
+		Dimension dimension = pitchViewport.toLocal(pCoordinate, true);
 		return dimension.height - (pImage.getHeight() / 2);
 	}
 
@@ -129,10 +133,10 @@ public abstract class FieldLayer {
 
 	public void clear(FieldCoordinate pCoordinate, boolean pUpdateArea) {
 		if ((pCoordinate != null) && FieldCoordinateBounds.FIELD.isInBounds(pCoordinate)) {
-			Dimension dimension = pitchDimensionProvider.mapToLocal(pCoordinate);
+			Dimension dimension = pitchViewport.toLocal(pCoordinate);
 			int fieldX = dimension.width;
 			int fieldY = dimension.height;
-			clear(fieldX, fieldY, pitchDimensionProvider.fieldSquareSize(), pitchDimensionProvider.fieldSquareSize(), pUpdateArea);
+			clear(fieldX, fieldY, pitchViewport.squareSize(), pitchViewport.squareSize(), pUpdateArea);
 		}
 	}
 

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerBloodspots.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerBloodspots.java
@@ -13,8 +13,9 @@ import java.awt.image.BufferedImage;
  */
 public class FieldLayerBloodspots extends FieldLayer {
 
-	public FieldLayerBloodspots(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerBloodspots(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+															PitchViewport pitchViewport, FontCache fontCache) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 	}
 
 	public void drawBloodspot(BloodSpot pBloodspot) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerEnhancements.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerEnhancements.java
@@ -6,8 +6,9 @@ import com.fumbbl.ffb.model.stadium.OnPitchEnhancement;
 import java.awt.image.BufferedImage;
 
 public class FieldLayerEnhancements extends FieldLayer {
-	public FieldLayerEnhancements(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerEnhancements(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+																PitchViewport pitchViewport, FontCache fontCache) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 	}
 
 	public void addEnhancement(OnPitchEnhancement enhancement) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerMarker.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerMarker.java
@@ -25,8 +25,9 @@ public class FieldLayerMarker extends FieldLayer {
 
 	private final Map<FieldCoordinate, Rectangle> fFieldMarkerBounds;
 
-	public FieldLayerMarker(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerMarker(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+													PitchViewport pitchViewport, FontCache fontCache) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 		fFieldMarkerBounds = new HashMap<>();
 	}
 

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerMarker.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerMarker.java
@@ -50,7 +50,7 @@ public class FieldLayerMarker extends FieldLayer {
 			}
 			FontMetrics metrics = g2d.getFontMetrics();
 			Rectangle2D textBounds = metrics.getStringBounds(pFieldMarker.getHomeText(), g2d);
-			Dimension dimension = pitchDimensionProvider.mapToLocal(pFieldMarker.getCoordinate(), true);
+			Dimension dimension = pitchViewport.toLocal(pFieldMarker.getCoordinate(), true);
 			int x = dimension.width - (int) (textBounds.getWidth() / 2) + 1;
 			int y = dimension.height + (int) (textBounds.getHeight() / 2) - 2;
 			g2d.drawString(pFieldMarker.getHomeText(), x, y);

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerOverPlayers.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerOverPlayers.java
@@ -38,8 +38,9 @@ public class FieldLayerOverPlayers extends FieldLayer {
 	private FieldCoordinate fThrownPlayerCoordinate;
 	private FieldCoordinate fMarkerCoordinate;
 
-	public FieldLayerOverPlayers(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerOverPlayers(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+															 PitchViewport pitchViewport, FontCache fontCache) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 	}
 
 	public void removeThrownPlayer() {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerOverPlayers.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerOverPlayers.java
@@ -71,7 +71,7 @@ public class FieldLayerOverPlayers extends FieldLayer {
 		if (pPushbackSquare != null) {
 			clear(pPushbackSquare.getCoordinate(), true);
 			IconCache iconCache = getClient().getUserInterface().getIconCache();
-			Direction localDirection = pitchDimensionProvider.mapToLocal(pPushbackSquare.getDirection());
+			Direction localDirection = pitchViewport.toLocal(pPushbackSquare.getDirection());
 			BufferedImage pushbackIcon = iconCache.getPushbackIcon(localDirection, pPushbackSquare.isSelected(), pitchDimensionProvider);
 			draw(pushbackIcon, pPushbackSquare.getCoordinate(), 1.0f);
 		}
@@ -126,15 +126,15 @@ public class FieldLayerOverPlayers extends FieldLayer {
 				clear(pMoveSquare.getCoordinate(), true);
 			}
 
-			Dimension dimensionWithOffset = pitchDimensionProvider.mapToLocal(pMoveSquare.getCoordinate(), true);
-			Dimension dimension = pitchDimensionProvider.mapToLocal(pMoveSquare.getCoordinate());
+			Dimension dimensionWithOffset = pitchViewport.toLocal(pMoveSquare.getCoordinate(), true);
+			Dimension dimension = pitchViewport.toLocal(pMoveSquare.getCoordinate());
 			int x = dimension.width + 2;
 			int y = dimension.height + 2;
 			Graphics2D g2d = getImage().createGraphics();
 			GraphicsEnhancer.applyAAHints(g2d);
 
 			g2d.setPaint(COLOR_MOVE_SQUARE);
-			Rectangle bounds = new Rectangle(x, y, pitchDimensionProvider.fieldSquareSize() - 4, pitchDimensionProvider.fieldSquareSize() - 4);
+			Rectangle bounds = new Rectangle(x, y, pitchViewport.squareSize() - 4, pitchViewport.squareSize() - 4);
 			g2d.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
 
 			g2d.setColor(COLOR_TARGET_NUMBER);
@@ -210,7 +210,7 @@ public class FieldLayerOverPlayers extends FieldLayer {
 		if ((pMarkerCoordinate != null) && !pMarkerCoordinate.equals(fMarkerCoordinate)) {
 			fMarkerCoordinate = pMarkerCoordinate;
 			clear(fMarkerCoordinate, true);
-			Dimension dimension = pitchDimensionProvider.mapToLocal(fMarkerCoordinate);
+			Dimension dimension = pitchViewport.toLocal(fMarkerCoordinate);
 			Graphics2D g2d = getImage().createGraphics();
 			IconCache iconCache = getClient().getUserInterface().getIconCache();
 			BufferedImage spellIcon = iconCache.getIconByProperty(iconProperty, pitchDimensionProvider);
@@ -233,7 +233,7 @@ public class FieldLayerOverPlayers extends FieldLayer {
 		if ((pMarkerCoordinate != null) && !pMarkerCoordinate.equals(fMarkerCoordinate)) {
 			fMarkerCoordinate = pMarkerCoordinate;
 			clear(fMarkerCoordinate, true);
-			Dimension dimension = pitchDimensionProvider.mapToLocal(fMarkerCoordinate);
+			Dimension dimension = pitchViewport.toLocal(fMarkerCoordinate);
 			Graphics2D g2d = getImage().createGraphics();
 			IconCache iconCache = getClient().getUserInterface().getIconCache();
 			BufferedImage fireballIcon = iconCache.getIconByProperty(IIconProperty.GAME_FIREBALL_SMALL, pitchDimensionProvider);
@@ -270,8 +270,8 @@ public class FieldLayerOverPlayers extends FieldLayer {
 	private void markSquare(FieldCoordinate pCoordinate, Color pColor) {
 		if (pCoordinate != null) {
 			clear(pCoordinate, true);
-			Dimension dimension = pitchDimensionProvider.mapToLocal(pCoordinate);
-			Rectangle bounds = new Rectangle(dimension.width + 1, dimension.height + 1, pitchDimensionProvider.fieldSquareSize() - 2, pitchDimensionProvider.fieldSquareSize() - 2);
+			Dimension dimension = pitchViewport.toLocal(pCoordinate);
+			Rectangle bounds = new Rectangle(dimension.width + 1, dimension.height + 1, pitchViewport.squareSize() - 2, pitchViewport.squareSize() - 2);
 			Graphics2D g2d = getImage().createGraphics();
 			g2d.setPaint(pColor);
 			g2d.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerPitch.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerPitch.java
@@ -5,6 +5,7 @@ import com.fumbbl.ffb.client.FantasyFootballClient;
 import com.fumbbl.ffb.client.FontCache;
 import com.fumbbl.ffb.client.IconCache;
 import com.fumbbl.ffb.client.PitchDimensionProvider;
+import com.fumbbl.ffb.client.PitchViewport;
 import com.fumbbl.ffb.client.UiDimensionProvider;
 import com.fumbbl.ffb.client.ui.GraphicsEnhancer;
 import com.fumbbl.ffb.model.FieldModel;
@@ -24,8 +25,10 @@ import java.awt.image.BufferedImage;
  */
 public class FieldLayerPitch extends FieldLayer {
 
-	public FieldLayerPitch(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerPitch(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider,
+												 PitchDimensionProvider pitchDimensionProvider,
+												 PitchViewport pitchViewport, FontCache fontCache) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 	}
 
 	public void drawWeather(Weather pWeather) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerPitch.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerPitch.java
@@ -75,10 +75,10 @@ public class FieldLayerPitch extends FieldLayer {
 			int translateY;
 			if (pitchDimensionProvider.isPitchPortrait()) {
 				translateX = (int) (((double) getImage().getWidth() / 2) - (teamNameBounds.getWidth() / 2));
-				translateY = (int) (pitchDimensionProvider.fieldSquareSize(25.5) + (teamNameBounds.getHeight() / 2)) - 4;
+				translateY = (int) (pitchViewport.squareSize(25.5) + (teamNameBounds.getHeight() / 2)) - 4;
 				g2d.translate(translateX, translateY);
 			} else {
-				translateX = (int) (pitchDimensionProvider.fieldSquareSize(0.5) + (teamNameBounds.getHeight() / 2)) - 4;
+				translateX = (int) (pitchViewport.squareSize(0.5) + (teamNameBounds.getHeight() / 2)) - 4;
 				translateY = (int) (((double) getImage().getHeight() / 2) + (teamNameBounds.getWidth() / 2));
 				g2d.translate(translateX, translateY);
 				g2d.rotate(-Math.PI / 2.0);
@@ -91,10 +91,10 @@ public class FieldLayerPitch extends FieldLayer {
 			teamNameBounds = metrics.getStringBounds(teamNameAway, g2d);
 			if (pitchDimensionProvider.isPitchPortrait()) {
 				translateX = (int) (((double) getImage().getWidth() / 2) - (teamNameBounds.getWidth() / 2));
-				translateY = (int) (pitchDimensionProvider.fieldSquareSize(0.5) + (teamNameBounds.getHeight() / 2)) - 4;
+				translateY = (int) (pitchViewport.squareSize(0.5) + (teamNameBounds.getHeight() / 2)) - 4;
 				g2d.translate(translateX, translateY);
 			} else {
-				translateX = (int) (pitchDimensionProvider.fieldSquareSize(25) + (teamNameBounds.getHeight() / 2)) - 4;
+				translateX = (int) (pitchViewport.squareSize(25) + (teamNameBounds.getHeight() / 2)) - 4;
 				translateY = (int) (((double) getImage().getHeight() / 2) - (teamNameBounds.getWidth() / 2));
 				g2d.translate(translateX, translateY);
 				g2d.rotate(Math.PI / 2.0);

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerPlayers.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerPlayers.java
@@ -20,8 +20,9 @@ import java.util.List;
  */
 public class FieldLayerPlayers extends FieldLayer {
 
-	public FieldLayerPlayers(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerPlayers(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+													 PitchViewport pitchViewport, FontCache fontCache) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 	}
 
 	public void refresh(FieldCoordinateBounds pBounds) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerPlayers.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerPlayers.java
@@ -36,7 +36,7 @@ public class FieldLayerPlayers extends FieldLayer {
 	public void updateBallAndPlayers(FieldCoordinate pCoordinate, boolean pPlayerOverBall) {
 		if ((pCoordinate != null) && !pCoordinate.isBoxCoordinate()) {
 			Game game = getClient().getGame();
-			Dimension dimension = pitchDimensionProvider.mapToLocal(pCoordinate, true);
+			Dimension dimension = pitchViewport.toLocal(pCoordinate, true);
 			Dimension maxIconSize = pitchDimensionProvider.dimension(Component.MAX_ICON);
 			int x = dimension.width - (maxIconSize.width / 2);
 			int y = dimension.height - (maxIconSize.height / 2);

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerRangeGrid.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerRangeGrid.java
@@ -20,8 +20,9 @@ public class FieldLayerRangeGrid extends FieldLayer {
 
 	private FieldCoordinate fCenterCoordinate;
 
-	public FieldLayerRangeGrid(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerRangeGrid(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+														 PitchViewport pitchViewport, FontCache fontCache) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 	}
 
 	public boolean drawRangeGrid(FieldCoordinate pCenterCoordinate, boolean pThrowTeamMate) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerRangeGrid.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerRangeGrid.java
@@ -59,10 +59,10 @@ public class FieldLayerRangeGrid extends FieldLayer {
 
 	private void markSquare(FieldCoordinate pCoordinate, Color pColor) {
 		if ((pCoordinate != null) && FieldCoordinateBounds.FIELD.isInBounds(pCoordinate)) {
-			Dimension dimension = pitchDimensionProvider.mapToLocal(pCoordinate);
+			Dimension dimension = pitchViewport.toLocal(pCoordinate);
 			int x = dimension.width;
 			int y = dimension.height;
-			Rectangle bounds = new Rectangle(x + 1, y + 1, pitchDimensionProvider.fieldSquareSize() - 2, pitchDimensionProvider.fieldSquareSize() - 2);
+			Rectangle bounds = new Rectangle(x + 1, y + 1, pitchViewport.squareSize() - 2, pitchViewport.squareSize() - 2);
 			Graphics2D g2d = getImage().createGraphics();
 			g2d.setPaint(pColor);
 			g2d.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerRangeRuler.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerRangeRuler.java
@@ -57,8 +57,9 @@ public class FieldLayerRangeRuler extends FieldLayer {
 	private FieldCoordinate fSelectSquareCoordinate;
 	private FieldCoordinate[] fMarkedCoordinates;
 
-	public FieldLayerRangeRuler(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerRangeRuler(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+															PitchViewport pitchViewport, FontCache fontCache) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 	}
 
 	public void drawRangeRuler(RangeRuler pRangeRuler) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerRangeRuler.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerRangeRuler.java
@@ -78,9 +78,9 @@ public class FieldLayerRangeRuler extends FieldLayer {
 			PassingDistance passingDistance = mechanic.findPassingDistance(game, throwerCoordinate,
 				pRangeRuler.getTargetCoordinate(), false);
 			if (passingDistance != null) {
-				Dimension startDimension = pitchDimensionProvider.mapToLocal(throwerCoordinate, true);
+				Dimension startDimension = pitchViewport.toLocal(throwerCoordinate, true);
 				Point startCenter = new Point(startDimension.width, startDimension.height);
-				Dimension endDimension = pitchDimensionProvider.mapToLocal(pRangeRuler.getTargetCoordinate(), true);
+				Dimension endDimension = pitchViewport.toLocal(pRangeRuler.getTargetCoordinate(), true);
 				Point endCenter = new Point(endDimension.width, endDimension.height);
 
 				int lengthY = startCenter.y - endCenter.y;
@@ -167,7 +167,7 @@ public class FieldLayerRangeRuler extends FieldLayer {
 
 		if (pMaxLength > 0) {
 
-			int halfRulerWidth = (int) (pitchDimensionProvider.fieldSquareSize() * UtilPassing.RULER_WIDTH / 2);
+			int halfRulerWidth = (int) (pitchViewport.squareSize() * UtilPassing.RULER_WIDTH / 2);
 			Point point1 = new Point(pStartCenter.x, pStartCenter.y - halfRulerWidth);
 			point1 = rotate(point1, pStartCenter, pSinPhi, pCosPhi);
 			Point point2 = new Point(pStartCenter.x, pStartCenter.y + halfRulerWidth);
@@ -199,8 +199,8 @@ public class FieldLayerRangeRuler extends FieldLayer {
 
 	private void drawSelectSquare(FieldCoordinate pCoordinate, Color pColor, Color border) {
 		if ((pCoordinate != null) && FieldCoordinateBounds.FIELD.isInBounds(pCoordinate)) {
-			Dimension dimension = pitchDimensionProvider.mapToLocal(pCoordinate);
-			Rectangle bounds = new Rectangle(dimension.width, dimension.height, pitchDimensionProvider.fieldSquareSize(), pitchDimensionProvider.fieldSquareSize());
+			Dimension dimension = pitchViewport.toLocal(pCoordinate);
+			Rectangle bounds = new Rectangle(dimension.width, dimension.height, pitchViewport.squareSize(), pitchViewport.squareSize());
 			Graphics2D g2d = getImage().createGraphics();
 			g2d.setPaint(pColor);
 			g2d.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerSketches.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerSketches.java
@@ -62,7 +62,7 @@ public class FieldLayerSketches extends FieldLayer {
 			int[] yPoints = new int[nPoints];
 			for (int i = 0; i < nPoints; i++) {
 				FieldCoordinate coordinate = sketch.getPath().get(i);
-				Dimension dimension = pitchDimensionProvider.mapToLocal(coordinate, true);
+				Dimension dimension = pitchViewport.toLocal(coordinate, true);
 				xPoints[i] = dimension.width;
 				yPoints[i] = dimension.height;
 			}
@@ -88,7 +88,7 @@ public class FieldLayerSketches extends FieldLayer {
 
 			FieldCoordinate previewCoordinate = sketchState.getPreviewCoordinate();
 			if (sketch.getId().equals(sketchState.getActiveSketchId())  && previewCoordinate != sketch.getPath().getLast() && previewCoordinate != null) {
-				Dimension dimension = pitchDimensionProvider.mapToLocal(previewCoordinate, true);
+				Dimension dimension = pitchViewport.toLocal(previewCoordinate, true);
 				graphics2D.setPaint(highlightPaint);
 				graphics2D.drawLine(
 					xPoints[nPoints - 1], yPoints[nPoints - 1],

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerSketches.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerSketches.java
@@ -5,6 +5,7 @@ import com.fumbbl.ffb.client.Component;
 import com.fumbbl.ffb.client.FantasyFootballClient;
 import com.fumbbl.ffb.client.FontCache;
 import com.fumbbl.ffb.client.PitchDimensionProvider;
+import com.fumbbl.ffb.client.PitchViewport;
 import com.fumbbl.ffb.client.UiDimensionProvider;
 import com.fumbbl.ffb.client.overlay.sketch.ClientSketchManager;
 import com.fumbbl.ffb.client.overlay.sketch.TriangleCoords;
@@ -25,8 +26,9 @@ public class FieldLayerSketches extends FieldLayer {
 
 	private final ClientSketchManager sketchManager;
 
-	public FieldLayerSketches(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache, ClientSketchManager sketchManager) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerSketches(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+														PitchViewport pitchViewport, FontCache fontCache, ClientSketchManager sketchManager) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 		this.sketchManager = sketchManager;
 	}
 

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerTackleZones.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerTackleZones.java
@@ -25,6 +25,7 @@ import com.fumbbl.ffb.TurnMode;
 import com.fumbbl.ffb.client.FantasyFootballClient;
 import com.fumbbl.ffb.client.FontCache;
 import com.fumbbl.ffb.client.PitchDimensionProvider;
+import com.fumbbl.ffb.client.PitchViewport;
 import com.fumbbl.ffb.client.StyleProvider;
 import com.fumbbl.ffb.client.UiDimensionProvider;
 import com.fumbbl.ffb.model.FieldModel;
@@ -54,8 +55,9 @@ public class FieldLayerTackleZones extends FieldLayer {
 	private final StyleProvider styleProvider;
 
 	public FieldLayerTackleZones(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider,
-															 PitchDimensionProvider pitchDimensionProvider, FontCache fontCache, StyleProvider styleProvider) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+															 PitchDimensionProvider pitchDimensionProvider, PitchViewport pitchViewport,
+															 FontCache fontCache, StyleProvider styleProvider) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 		this.styleProvider = styleProvider;
 	}
 

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerTackleZones.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerTackleZones.java
@@ -152,7 +152,7 @@ public class FieldLayerTackleZones extends FieldLayer {
 
 	private void drawContours(Graphics2D g2d, FieldCoordinate coordinate, Set<FieldCoordinate> processedCoords) {
 		List<Direction> directions = borderDirections(coordinate, processedCoords);
-		Dimension origin = pitchDimensionProvider.mapToLocal(coordinate);
+		Dimension origin = pitchViewport.toLocal(coordinate);
 		for (Direction direction : directions) {
 			drawContour(g2d, contourOrigin(origin, direction), contourTarget(origin, direction));
 		}
@@ -172,21 +172,21 @@ public class FieldLayerTackleZones extends FieldLayer {
 		if (!processedCoords.contains(new FieldCoordinate(coordinate.getX() + 1, coordinate.getY()))) {
 			directions.add(Direction.EAST);
 		}
-		return directions.stream().map(pitchDimensionProvider::mapToLocal).collect(Collectors.toList());
+		return directions.stream().map(pitchViewport::toLocal).collect(Collectors.toList());
 	}
 
 	private void drawTackleZone(Graphics2D g2d, FieldCoordinate coordinate) {
-		Dimension origin = pitchDimensionProvider.mapToLocal(coordinate);
+		Dimension origin = pitchViewport.toLocal(coordinate);
 		paintZoneRect(g2d, origin.width, origin.height);
 	}
 
 	private Dimension contourOrigin(Dimension upperLeft, Direction fromPlayer) {
 		switch (fromPlayer) {
 			case SOUTH:
-				return new Dimension(upperLeft.width, upperLeft.height + pitchDimensionProvider.fieldSquareSize());
+				return new Dimension(upperLeft.width, upperLeft.height + pitchViewport.squareSize());
 
 			case EAST:
-				return new Dimension(upperLeft.width + pitchDimensionProvider.fieldSquareSize(), upperLeft.height);
+				return new Dimension(upperLeft.width + pitchViewport.squareSize(), upperLeft.height);
 
 			default:
 				return upperLeft;
@@ -196,14 +196,14 @@ public class FieldLayerTackleZones extends FieldLayer {
 	private Dimension contourTarget(Dimension upperLeft, Direction fromPlayer) {
 		switch (fromPlayer) {
 			case NORTH:
-				return new Dimension(upperLeft.width + pitchDimensionProvider.fieldSquareSize(), upperLeft.height);
+				return new Dimension(upperLeft.width + pitchViewport.squareSize(), upperLeft.height);
 
 			case WEST:
-				return new Dimension(upperLeft.width, upperLeft.height + pitchDimensionProvider.fieldSquareSize());
+				return new Dimension(upperLeft.width, upperLeft.height + pitchViewport.squareSize());
 
 			case EAST:
 			case SOUTH:
-				return new Dimension(upperLeft.width + pitchDimensionProvider.fieldSquareSize(), upperLeft.height + pitchDimensionProvider.fieldSquareSize());
+				return new Dimension(upperLeft.width + pitchViewport.squareSize(), upperLeft.height + pitchViewport.squareSize());
 			default:
 				return upperLeft;
 		}
@@ -212,7 +212,7 @@ public class FieldLayerTackleZones extends FieldLayer {
 	// Paints a single colored translucent zone square.
 	private void paintZoneRect(Graphics2D g2d, int x, int y) {
 		g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, ALPHA));
-		g2d.fillRect(x, y, pitchDimensionProvider.fieldSquareSize(), pitchDimensionProvider.fieldSquareSize());
+		g2d.fillRect(x, y, pitchViewport.squareSize(), pitchViewport.squareSize());
 	}
 
 	//Draws a dashed contour for the given edges list.

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerTeamLogo.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerTeamLogo.java
@@ -53,7 +53,7 @@ public class FieldLayerTeamLogo extends FieldLayer {
     Color heightColor = HOME_COLOR;
     FieldCoordinate homeZone = new FieldCoordinate(1, pY);
     clear(homeZone, true); // marks square as updated
-    Dimension dimension = pitchDimensionProvider.mapToLocal(homeZone, true);
+    Dimension dimension = pitchViewport.toLocal(homeZone, true);
     int x = dimension.width;
     int y = dimension.height;
 
@@ -75,7 +75,7 @@ public class FieldLayerTeamLogo extends FieldLayer {
 
     FieldCoordinate lowerLine = new FieldCoordinate(24, pY);
     clear(lowerLine, true); // marks square as updated
-    dimension = pitchDimensionProvider.mapToLocal(lowerLine, true);
+    dimension = pitchViewport.toLocal(lowerLine, true);
     x = dimension.width;
     y = dimension.height;
 
@@ -114,7 +114,7 @@ public class FieldLayerTeamLogo extends FieldLayer {
     g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.7f));
     FieldCoordinate upperLine = new FieldCoordinate(pX, 0);
     clear(upperLine, true); // marks square as updated
-    Dimension dimension = pitchDimensionProvider.mapToLocal(upperLine, true);
+    Dimension dimension = pitchViewport.toLocal(upperLine, true);
     int x = dimension.width;
     int y = dimension.height;
 
@@ -132,7 +132,7 @@ public class FieldLayerTeamLogo extends FieldLayer {
     g2d.drawString(distanceString, x, y);
     FieldCoordinate lowerLine = new FieldCoordinate(pX, 14);
     clear(lowerLine, true); // marks square as updated
-    dimension = pitchDimensionProvider.mapToLocal(lowerLine, true);
+    dimension = pitchViewport.toLocal(lowerLine, true);
     x = dimension.width;
     y = dimension.height;
 
@@ -162,22 +162,22 @@ public class FieldLayerTeamLogo extends FieldLayer {
         int x, y;
         if (pitchDimensionProvider.isPitchPortrait()) {
           if (pHomeTeam) {
-            y = (3 * (fieldDimension.height / 4)) - (teamLogo.getHeight() / 2) - pitchDimensionProvider.imageOffset();
+            y = (3 * (fieldDimension.height / 4)) - (teamLogo.getHeight() / 2) - pitchViewport.imageOffset();
           } else {
-            y = (fieldDimension.height / 4) - (teamLogo.getHeight() / 2) + pitchDimensionProvider.imageOffset();
+            y = (fieldDimension.height / 4) - (teamLogo.getHeight() / 2) + pitchViewport.imageOffset();
           }
           x = (fieldDimension.width / 2) - (teamLogo.getWidth() / 2);
-          g2d.setClip(0, pHomeTeam ? fieldDimension.height / 2 : pitchDimensionProvider.fieldSquareSize(),
-            fieldDimension.width, (fieldDimension.height / 2) - pitchDimensionProvider.fieldSquareSize());
+          g2d.setClip(0, pHomeTeam ? fieldDimension.height / 2 : pitchViewport.squareSize(),
+            fieldDimension.width, (fieldDimension.height / 2) - pitchViewport.squareSize());
         } else {
           if (pHomeTeam) {
-            x = (fieldDimension.width / 4) - (teamLogo.getWidth() / 2) + pitchDimensionProvider.imageOffset();
+            x = (fieldDimension.width / 4) - (teamLogo.getWidth() / 2) + pitchViewport.imageOffset();
           } else {
-            x = (3 * (fieldDimension.width / 4)) - (teamLogo.getWidth() / 2) - pitchDimensionProvider.imageOffset();
+            x = (3 * (fieldDimension.width / 4)) - (teamLogo.getWidth() / 2) - pitchViewport.imageOffset();
           }
           y = (fieldDimension.height / 2) - (teamLogo.getHeight() / 2);
-          g2d.setClip(pHomeTeam ? pitchDimensionProvider.fieldSquareSize() : fieldDimension.width / 2, 0,
-            (fieldDimension.width / 2) - pitchDimensionProvider.fieldSquareSize(), fieldDimension.height);
+          g2d.setClip(pHomeTeam ? pitchViewport.squareSize() : fieldDimension.width / 2, 0,
+            (fieldDimension.width / 2) - pitchViewport.squareSize(), fieldDimension.height);
         }
         g2d.drawImage(teamLogo, x, y, null);
         g2d.dispose();

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerTeamLogo.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerTeamLogo.java
@@ -25,8 +25,9 @@ public class FieldLayerTeamLogo extends FieldLayer {
   private static final String[] LETTERS =
     new String[]{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"};
 
-  public FieldLayerTeamLogo(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-    super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+  public FieldLayerTeamLogo(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+                            PitchViewport pitchViewport, FontCache fontCache) {
+    super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
   }
 
   public void drawDistanceMarkers() {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerUnderPlayers.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerUnderPlayers.java
@@ -28,8 +28,9 @@ public class FieldLayerUnderPlayers extends FieldLayer {
 
 	private FieldCoordinate[] fMovePath;
 
-	public FieldLayerUnderPlayers(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider, FontCache fontCache) {
-		super(pClient, uiDimensionProvider, pitchDimensionProvider, fontCache);
+	public FieldLayerUnderPlayers(FantasyFootballClient pClient, UiDimensionProvider uiDimensionProvider, PitchDimensionProvider pitchDimensionProvider,
+																PitchViewport pitchViewport, FontCache fontCache) {
+		super(pClient, uiDimensionProvider, pitchDimensionProvider, pitchViewport, fontCache);
 	}
 
 	public void drawTrackNumber(TrackNumber pTrackNumber) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerUnderPlayers.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layer/FieldLayerUnderPlayers.java
@@ -74,7 +74,7 @@ public class FieldLayerUnderPlayers extends FieldLayer {
 			g2d.setFont(fontCache.font(Font.BOLD, 15, pitchDimensionProvider));
 			FontMetrics metrics = g2d.getFontMetrics();
 			Rectangle2D numberBounds = metrics.getStringBounds(numberString, g2d);
-			Dimension dimension = pitchDimensionProvider.mapToLocal(pCoordinate, true);
+			Dimension dimension = pitchViewport.toLocal(pCoordinate, true);
 			int baselineX = dimension.width - (int) (numberBounds.getWidth() / 2) + 1;
 			int baselineY = dimension.height + (int) (numberBounds.getHeight() / 2) - 2;
 			g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.7f));

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layout/ClientLayoutCalculator.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layout/ClientLayoutCalculator.java
@@ -1,0 +1,106 @@
+package com.fumbbl.ffb.client.layout;
+
+import com.fumbbl.ffb.client.ClientLayout;
+import com.fumbbl.ffb.client.Component;
+import com.fumbbl.ffb.client.UiDimensionProvider;
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+
+public class ClientLayoutCalculator {
+
+	private static final int LOG_CHAT_GAP = 2;
+	private static final int PANEL_BORDER = 1;
+
+	public ClientLayoutResult calculate(UiDimensionProvider uiDimensionProvider) {
+		Dimension field = uiDimensionProvider.dimension(Component.FIELD);
+		Dimension sidebar = uiDimensionProvider.dimension(Component.SIDEBAR);
+		Dimension score = uiDimensionProvider.dimension(Component.SCORE_BOARD);
+		Dimension log = uiDimensionProvider.dimension(Component.LOG);
+		Dimension chat = uiDimensionProvider.dimension(Component.CHAT);
+
+		ClientLayout layout = uiDimensionProvider.getLayoutSettings().getLayout();
+		switch (layout) {
+			case PORTRAIT:
+				return portrait(field, sidebar, score, log, chat);
+			case SQUARE:
+				return square(field, sidebar, score, log, chat);
+			default:
+				return landscape(field, sidebar, score, log, chat);
+		}
+	}
+
+	private ClientLayoutResult landscape(Dimension field, Dimension sidebar, Dimension score, Dimension log, Dimension chat) {
+		int logChatPanelWidth = log.width + LOG_CHAT_GAP + chat.width + (2 * PANEL_BORDER);
+		int logChatPanelHeight = Math.max(log.height, chat.height) + (2 * PANEL_BORDER);
+		int centerWidth = Math.max(field.width, Math.max(score.width, logChatPanelWidth));
+		int centerHeight = field.height + score.height + logChatPanelHeight;
+
+		Dimension preferredSize = new Dimension(sidebar.width + centerWidth + sidebar.width,
+			Math.max(sidebar.height, centerHeight));
+
+		int centerX = sidebar.width;
+		int logChatY = field.height + score.height;
+		int logY = logChatY + PANEL_BORDER;
+		int logX = centerX + PANEL_BORDER;
+		int chatX = logX + log.width + LOG_CHAT_GAP;
+
+		return new ClientLayoutResult(
+			preferredSize,
+			new Rectangle(centerX, 0, field.width, field.height),
+			new Rectangle(0, 0, sidebar.width, preferredSize.height),
+			new Rectangle(centerX + centerWidth, 0, sidebar.width, preferredSize.height),
+			new Rectangle(centerX, field.height, score.width, score.height),
+			new Rectangle(logX, logY, log.width, log.height),
+			new Rectangle(chatX, logY, chat.width, chat.height)
+		);
+	}
+
+	private ClientLayoutResult portrait(Dimension field, Dimension sidebar, Dimension score, Dimension log, Dimension chat) {
+		int mainWidth = sidebar.width + field.width + sidebar.width;
+		int mainHeight = Math.max(sidebar.height, field.height);
+		int logChatPanelWidth = log.width + LOG_CHAT_GAP + chat.width + (2 * PANEL_BORDER);
+		int logChatPanelHeight = Math.max(log.height, chat.height) + (2 * PANEL_BORDER);
+
+		Dimension preferredSize = new Dimension(Math.max(mainWidth, Math.max(score.width, logChatPanelWidth)),
+			mainHeight + score.height + logChatPanelHeight);
+
+		int scoreY = mainHeight;
+		int logChatY = scoreY + score.height;
+		int logY = logChatY + PANEL_BORDER;
+		int logX = PANEL_BORDER;
+		int chatX = logX + log.width + LOG_CHAT_GAP;
+
+		return new ClientLayoutResult(
+			preferredSize,
+			new Rectangle(sidebar.width, 0, field.width, field.height),
+			new Rectangle(0, 0, sidebar.width, mainHeight),
+			new Rectangle(sidebar.width + field.width, 0, sidebar.width, mainHeight),
+			new Rectangle(0, scoreY, score.width, score.height),
+			new Rectangle(logX, logY, log.width, log.height),
+			new Rectangle(chatX, logY, chat.width, chat.height)
+		);
+	}
+
+	private ClientLayoutResult square(Dimension field, Dimension sidebar, Dimension score, Dimension log, Dimension chat) {
+		int mainWidth = sidebar.width + field.width + sidebar.width;
+		int mainHeight = Math.max(sidebar.height, field.height);
+		int logChatScoreWidth = Math.max(log.width, Math.max(score.width, chat.width)) + (2 * PANEL_BORDER);
+		int logChatScoreHeight = log.height + score.height + chat.height + (2 * PANEL_BORDER);
+
+		Dimension preferredSize = new Dimension(mainWidth + logChatScoreWidth,
+			Math.max(mainHeight, logChatScoreHeight));
+
+		int rightX = mainWidth + PANEL_BORDER;
+
+		return new ClientLayoutResult(
+			preferredSize,
+			new Rectangle(sidebar.width, 0, field.width, field.height),
+			new Rectangle(0, 0, sidebar.width, mainHeight),
+			new Rectangle(sidebar.width + field.width, 0, sidebar.width, mainHeight),
+			new Rectangle(rightX, log.height + PANEL_BORDER, score.width, score.height),
+			new Rectangle(rightX, PANEL_BORDER, log.width, log.height),
+			new Rectangle(rightX, log.height + score.height + PANEL_BORDER, chat.width, chat.height)
+		);
+	}
+}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layout/ClientLayoutPanel.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layout/ClientLayoutPanel.java
@@ -1,0 +1,56 @@
+package com.fumbbl.ffb.client.layout;
+
+import javax.swing.JPanel;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Rectangle;
+
+public class ClientLayoutPanel extends JPanel {
+
+	private final Component fieldComponent;
+	private final Component homeSidebar;
+	private final Component awaySidebar;
+	private final Component scoreBar;
+	private final Component log;
+	private final Component chat;
+
+	public ClientLayoutPanel(Component fieldComponent, Component homeSidebar, Component awaySidebar,
+	                         Component scoreBar, Component log, Component chat) {
+		super(null);
+		this.fieldComponent = fieldComponent;
+		this.homeSidebar = homeSidebar;
+		this.awaySidebar = awaySidebar;
+		this.scoreBar = scoreBar;
+		this.log = log;
+		this.chat = chat;
+
+		add(homeSidebar);
+		add(fieldComponent);
+		add(awaySidebar);
+		add(scoreBar);
+		add(log);
+		add(chat);
+	}
+
+	public void apply(ClientLayoutResult layoutResult) {
+		Dimension preferredSize = layoutResult.preferredSize();
+		setMinimumSize(preferredSize);
+		setPreferredSize(preferredSize);
+		setMaximumSize(preferredSize);
+		setSize(preferredSize);
+
+		applyBounds(fieldComponent, layoutResult.fieldBounds());
+		applyBounds(homeSidebar, layoutResult.homeSidebarBounds());
+		applyBounds(awaySidebar, layoutResult.awaySidebarBounds());
+		applyBounds(scoreBar, layoutResult.scoreBarBounds());
+		applyBounds(log, layoutResult.logBounds());
+		applyBounds(chat, layoutResult.chatBounds());
+
+		revalidate();
+		repaint();
+	}
+
+	private void applyBounds(Component component, Rectangle bounds) {
+		component.setBounds(bounds);
+	}
+}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layout/ClientLayoutResult.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/layout/ClientLayoutResult.java
@@ -1,0 +1,55 @@
+package com.fumbbl.ffb.client.layout;
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+
+public class ClientLayoutResult {
+
+	private final Dimension preferredSize;
+	private final Rectangle fieldBounds;
+	private final Rectangle homeSidebarBounds;
+	private final Rectangle awaySidebarBounds;
+	private final Rectangle scoreBarBounds;
+	private final Rectangle logBounds;
+	private final Rectangle chatBounds;
+
+	public ClientLayoutResult(Dimension preferredSize, Rectangle fieldBounds, Rectangle homeSidebarBounds,
+														Rectangle awaySidebarBounds, Rectangle scoreBarBounds, Rectangle logBounds,
+														Rectangle chatBounds) {
+		this.preferredSize = new Dimension(preferredSize);
+		this.fieldBounds = new Rectangle(fieldBounds);
+		this.homeSidebarBounds = new Rectangle(homeSidebarBounds);
+		this.awaySidebarBounds = new Rectangle(awaySidebarBounds);
+		this.scoreBarBounds = new Rectangle(scoreBarBounds);
+		this.logBounds = new Rectangle(logBounds);
+		this.chatBounds = new Rectangle(chatBounds);
+	}
+
+	public Dimension preferredSize() {
+		return new Dimension(preferredSize);
+	}
+
+	public Rectangle fieldBounds() {
+		return new Rectangle(fieldBounds);
+	}
+
+	public Rectangle homeSidebarBounds() {
+		return new Rectangle(homeSidebarBounds);
+	}
+
+	public Rectangle awaySidebarBounds() {
+		return new Rectangle(awaySidebarBounds);
+	}
+
+	public Rectangle scoreBarBounds() {
+		return new Rectangle(scoreBarBounds);
+	}
+
+	public Rectangle logBounds() {
+		return new Rectangle(logBounds);
+	}
+
+	public Rectangle chatBounds() {
+		return new Rectangle(chatBounds);
+	}
+}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/overlay/sketch/ClientSketchManager.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/overlay/sketch/ClientSketchManager.java
@@ -3,6 +3,7 @@ package com.fumbbl.ffb.client.overlay.sketch;
 import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.client.Component;
 import com.fumbbl.ffb.client.PitchDimensionProvider;
+import com.fumbbl.ffb.client.PitchViewport;
 import com.fumbbl.ffb.model.sketch.Sketch;
 
 import java.awt.Dimension;
@@ -24,16 +25,18 @@ public class ClientSketchManager {
 	@SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
 	private List<Sketch> sketches;
 	private final PitchDimensionProvider pitchDimensionProvider;
+	private final PitchViewport pitchViewport;
 	private final String coach;
 	private final Set<String> coachesPreventedFromSketching = new HashSet<>();
 	private final Set<String> hiddenCoaches = new HashSet<>();
 
 	private final Map<String, List<Sketch>> sketchesByCoach = new HashMap<>();
 
-	public ClientSketchManager(String coach, PitchDimensionProvider pitchDimensionProvider) {
+	public ClientSketchManager(String coach, PitchDimensionProvider pitchDimensionProvider, PitchViewport pitchViewport) {
 		this.coach = coach;
 		sketches = getSketches(coach);
 		this.pitchDimensionProvider = pitchDimensionProvider;
+		this.pitchViewport = pitchViewport;
 	}
 
 	private synchronized List<Sketch> getSketches(String coach) {
@@ -132,7 +135,7 @@ public class ClientSketchManager {
 		Iterator<FieldCoordinate> iterator = sketch.getPath().iterator();
 		FieldCoordinate currentNode = iterator.next();
 
-		if (inStartDecoration(pitchDimensionProvider.mapToLocal(currentNode, true), x, y)) {
+		if (inStartDecoration(pitchViewport.toLocal(currentNode, true), x, y)) {
 			return true;
 		}
 
@@ -140,8 +143,8 @@ public class ClientSketchManager {
 			FieldCoordinate previousNode = currentNode;
 			currentNode = iterator.next();
 			if (withinSpannedRectangle(
-				pitchDimensionProvider.mapToLocal(previousNode, true),
-				pitchDimensionProvider.mapToLocal(currentNode, true),
+				pitchViewport.toLocal(previousNode, true),
+				pitchViewport.toLocal(currentNode, true),
 				sketchWidth,
 				x, y
 			)) {
@@ -149,8 +152,8 @@ public class ClientSketchManager {
 			}
 		}
 
-		return inEndDecoration(pitchDimensionProvider.mapToLocal(currentNode, true),
-			pitchDimensionProvider.mapToLocal(sketch.getPath().getLast(), true), x, y);
+		return inEndDecoration(pitchViewport.toLocal(currentNode, true),
+			pitchViewport.toLocal(sketch.getPath().getLast(), true), x, y);
 	}
 
 	public synchronized void removeAll(String coach) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/report/ReportMessageBase.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/report/ReportMessageBase.java
@@ -68,8 +68,8 @@ public abstract class ReportMessageBase<T extends IReport> implements IKeyedItem
 	}
 
 	protected Direction mapToLocal(Direction direction) {
-		PitchDimensionProvider dimensionProvider = statusReport.getClient().getUserInterface().getPitchDimensionProvider();
-		return dimensionProvider.mapToLocal(direction);
+		PitchViewport pitchViewport = statusReport.getClient().getUserInterface().getPitchViewport();
+		return pitchViewport.toLocal(direction);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/CoordinateConverterTest.java
+++ b/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/CoordinateConverterTest.java
@@ -1,0 +1,34 @@
+package com.fumbbl.ffb.client;
+
+import com.fumbbl.ffb.FieldCoordinate;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Canvas;
+import java.awt.Point;
+import java.awt.event.MouseEvent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class CoordinateConverterTest {
+
+	@Test
+	void delegatesMouseEventPointToPitchViewport() {
+		PitchViewport pitchViewport = mock(PitchViewport.class);
+		CoordinateConverter coordinateConverter = new CoordinateConverter(pitchViewport);
+		FieldCoordinate expected = new FieldCoordinate(1, 0);
+
+		given(pitchViewport.toFieldCoordinate(new Point(30, 1))).willReturn(expected);
+
+		FieldCoordinate actual = coordinateConverter.getFieldCoordinate(mouseEventAt(30, 1));
+
+		assertEquals(expected, actual);
+		verify(pitchViewport).toFieldCoordinate(new Point(30, 1));
+	}
+
+	private MouseEvent mouseEventAt(int x, int y) {
+		return new MouseEvent(new Canvas(), MouseEvent.MOUSE_MOVED, 0, 0, x, y, 0, false);
+	}
+}

--- a/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/PitchViewportTest.java
+++ b/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/PitchViewportTest.java
@@ -41,6 +41,15 @@ class PitchViewportTest {
 	}
 
 	@Test
+	void squareSizeWithFactorUsesCurrentPitchSquareSizeRounding() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertEquals(15, viewport.squareSize(0.5));
+		assertEquals(750, viewport.squareSize(25));
+		assertEquals(765, viewport.squareSize(25.5));
+	}
+
+	@Test
 	void imageOffsetUsesCurrentPitchImageOffset() {
 		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
 

--- a/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/PitchViewportTest.java
+++ b/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/PitchViewportTest.java
@@ -1,0 +1,143 @@
+package com.fumbbl.ffb.client;
+
+import com.fumbbl.ffb.Direction;
+import com.fumbbl.ffb.FieldCoordinate;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Dimension;
+import java.awt.Point;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class PitchViewportTest {
+
+	private PitchViewport viewport(ClientLayout layout) {
+		LayoutSettings layoutSettings = new LayoutSettings(layout, 1.0);
+		UiDimensionProvider uiDimensionProvider = new UiDimensionProvider(layoutSettings);
+		PitchDimensionProvider pitchDimensionProvider = new PitchDimensionProvider(layoutSettings);
+		return new PitchViewport(uiDimensionProvider, pitchDimensionProvider);
+	}
+
+	@Test
+	void fieldSizeUsesCurrentLandscapeFieldDimension() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertEquals(new Dimension(782, 452), viewport.fieldSize());
+	}
+
+	@Test
+	void fieldSizeUsesCurrentPortraitFieldDimension() {
+		PitchViewport viewport = viewport(ClientLayout.PORTRAIT);
+
+		assertEquals(new Dimension(452, 782), viewport.fieldSize());
+	}
+
+	@Test
+	void squareSizeUsesCurrentPitchSquareSize() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertEquals(30, viewport.squareSize());
+	}
+
+	@Test
+	void imageOffsetUsesCurrentPitchImageOffset() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertEquals(15, viewport.imageOffset());
+	}
+
+	@Test
+	void landscapeCoordinateMapsToUpperLeftLocalSquare() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertEquals(new Dimension(0, 0), viewport.toLocal(new FieldCoordinate(0, 0)));
+		assertEquals(new Dimension(750, 420), viewport.toLocal(new FieldCoordinate(25, 14)));
+	}
+
+	@Test
+	void landscapeCoordinateMapsToLocalSquareCenter() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertEquals(new Dimension(15, 15), viewport.toLocal(new FieldCoordinate(0, 0), true));
+		assertEquals(new Dimension(765, 435), viewport.toLocal(new FieldCoordinate(25, 14), true));
+	}
+
+	@Test
+	void portraitCoordinateMapsToUpperLeftLocalSquare() {
+		PitchViewport viewport = viewport(ClientLayout.PORTRAIT);
+
+		assertEquals(new Dimension(0, 750), viewport.toLocal(new FieldCoordinate(0, 0)));
+		assertEquals(new Dimension(420, 0), viewport.toLocal(new FieldCoordinate(25, 14)));
+	}
+
+	@Test
+	void portraitCoordinateMapsToLocalSquareCenter() {
+		PitchViewport viewport = viewport(ClientLayout.PORTRAIT);
+
+		assertEquals(new Dimension(15, 765), viewport.toLocal(new FieldCoordinate(0, 0), true));
+		assertEquals(new Dimension(435, 15), viewport.toLocal(new FieldCoordinate(25, 14), true));
+	}
+
+	@Test
+	void landscapeLocalPointMapsToFieldCoordinate() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertEquals(new FieldCoordinate(0, 0), viewport.toFieldCoordinate(new Point(1, 1)));
+		assertEquals(new FieldCoordinate(1, 0), viewport.toFieldCoordinate(new Point(30, 1)));
+		assertEquals(new FieldCoordinate(25, 14), viewport.toFieldCoordinate(new Point(750, 420)));
+	}
+
+	@Test
+	void portraitLocalPointMapsToFieldCoordinateUsingCurrentCoordinateConverterBehavior() {
+		PitchViewport viewport = viewport(ClientLayout.PORTRAIT);
+
+		assertEquals(new FieldCoordinate(25, 0), viewport.toFieldCoordinate(new Point(1, 1)));
+		assertEquals(new FieldCoordinate(24, 0), viewport.toFieldCoordinate(new Point(1, 30)));
+		assertEquals(new FieldCoordinate(11, 14), viewport.toFieldCoordinate(new Point(420, 420)));
+	}
+
+	@Test
+	void localPointOutsideStrictCurrentBoundsReturnsNull() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertNull(viewport.toFieldCoordinate(new Point(0, 1)));
+		assertNull(viewport.toFieldCoordinate(new Point(1, 0)));
+		assertNull(viewport.toFieldCoordinate(new Point(782, 1)));
+		assertNull(viewport.toFieldCoordinate(new Point(1, 452)));
+	}
+
+	@Test
+	void landscapeDirectionsAreUnchanged() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertEquals(Direction.NORTH, viewport.toLocal(Direction.NORTH));
+		assertEquals(Direction.EAST, viewport.toLocal(Direction.EAST));
+		assertEquals(Direction.SOUTH, viewport.toLocal(Direction.SOUTH));
+		assertEquals(Direction.WEST, viewport.toLocal(Direction.WEST));
+	}
+
+	@Test
+	void portraitDirectionsUseCurrentRemapping() {
+		PitchViewport viewport = viewport(ClientLayout.PORTRAIT);
+
+		assertEquals(Direction.WEST, viewport.toLocal(Direction.NORTH));
+		assertEquals(Direction.NORTH, viewport.toLocal(Direction.EAST));
+		assertEquals(Direction.EAST, viewport.toLocal(Direction.SOUTH));
+		assertEquals(Direction.SOUTH, viewport.toLocal(Direction.WEST));
+		assertEquals(Direction.NORTHWEST, viewport.toLocal(Direction.NORTHEAST));
+		assertEquals(Direction.NORTHEAST, viewport.toLocal(Direction.SOUTHEAST));
+		assertEquals(Direction.SOUTHEAST, viewport.toLocal(Direction.SOUTHWEST));
+		assertEquals(Direction.SOUTHWEST, viewport.toLocal(Direction.NORTHWEST));
+	}
+
+	@Test
+	void localDirectionDelegatesToCurrentProviderBehavior() {
+		PitchViewport viewport = viewport(ClientLayout.PORTRAIT);
+
+		assertEquals(Direction.NORTH, viewport.getLocalDirection(
+			new FieldCoordinate(0, 0),
+			new FieldCoordinate(1, 0)
+		));
+	}
+}

--- a/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/PitchViewportTest.java
+++ b/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/PitchViewportTest.java
@@ -189,4 +189,62 @@ class PitchViewportTest {
 
 		assertEquals(new Rectangle(145, 0, 782, 452), viewport.viewportBounds());
 	}
+
+	@Test
+	void landscapeWorldCoordinateMapsToScreenPointUsingViewportOffset() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+		viewport.setViewportBounds(new Rectangle(145, 0, 782, 452));
+
+		assertEquals(new Point(145, 0), viewport.worldToScreen(new FieldCoordinate(0, 0)));
+		assertEquals(new Point(895, 420), viewport.worldToScreen(new FieldCoordinate(25, 14)));
+	}
+
+	@Test
+	void landscapeWorldCoordinateMapsToCenteredScreenPointUsingViewportOffset() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+		viewport.setViewportBounds(new Rectangle(145, 0, 782, 452));
+
+		assertEquals(new Point(160, 15), viewport.worldToScreen(new FieldCoordinate(0, 0), true));
+		assertEquals(new Point(910, 435), viewport.worldToScreen(new FieldCoordinate(25, 14), true));
+	}
+
+	@Test
+	void portraitWorldCoordinateMapsToScreenPointUsingViewportOffset() {
+		PitchViewport viewport = viewport(ClientLayout.PORTRAIT);
+		viewport.setViewportBounds(new Rectangle(165, 0, 452, 782));
+
+		assertEquals(new Point(165, 750), viewport.worldToScreen(new FieldCoordinate(0, 0)));
+		assertEquals(new Point(585, 0), viewport.worldToScreen(new FieldCoordinate(25, 14)));
+	}
+
+	@Test
+	void landscapeScreenPointMapsToWorldCoordinateUsingViewportOffset() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+		viewport.setViewportBounds(new Rectangle(145, 0, 782, 452));
+
+		assertEquals(new FieldCoordinate(0, 0), viewport.screenToWorld(new Point(146, 1)));
+		assertEquals(new FieldCoordinate(1, 0), viewport.screenToWorld(new Point(175, 1)));
+		assertEquals(new FieldCoordinate(25, 14), viewport.screenToWorld(new Point(895, 420)));
+	}
+
+	@Test
+	void portraitScreenPointMapsToWorldCoordinateUsingViewportOffset() {
+		PitchViewport viewport = viewport(ClientLayout.PORTRAIT);
+		viewport.setViewportBounds(new Rectangle(165, 0, 452, 782));
+
+		assertEquals(new FieldCoordinate(25, 0), viewport.screenToWorld(new Point(166, 1)));
+		assertEquals(new FieldCoordinate(24, 0), viewport.screenToWorld(new Point(166, 30)));
+		assertEquals(new FieldCoordinate(11, 14), viewport.screenToWorld(new Point(585, 420)));
+	}
+
+	@Test
+	void screenPointOutsideViewportMapsToNullUsingCurrentLocalBounds() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+		viewport.setViewportBounds(new Rectangle(145, 0, 782, 452));
+
+		assertNull(viewport.screenToWorld(new Point(145, 1)));
+		assertNull(viewport.screenToWorld(new Point(146, 0)));
+		assertNull(viewport.screenToWorld(new Point(927, 1)));
+		assertNull(viewport.screenToWorld(new Point(146, 452)));
+	}
 }

--- a/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/PitchViewportTest.java
+++ b/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/PitchViewportTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.Rectangle;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -148,5 +149,44 @@ class PitchViewportTest {
 			new FieldCoordinate(0, 0),
 			new FieldCoordinate(1, 0)
 		));
+	}
+
+	@Test
+	void viewportBoundsDefaultsToCurrentLandscapeFieldSizeAtOrigin() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		assertEquals(new Rectangle(0, 0, 782, 452), viewport.viewportBounds());
+	}
+
+	@Test
+	void viewportBoundsDefaultsToCurrentPortraitFieldSizeAtOrigin() {
+		PitchViewport viewport = viewport(ClientLayout.PORTRAIT);
+
+		assertEquals(new Rectangle(0, 0, 452, 782), viewport.viewportBounds());
+	}
+
+	@Test
+	void viewportBoundsCanBeUpdatedFromLayoutResult() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+
+		viewport.setViewportBounds(new Rectangle(145, 0, 782, 452));
+
+		assertEquals(new Rectangle(145, 0, 782, 452), viewport.viewportBounds());
+	}
+
+	@Test
+	void viewportBoundsUsesDefensiveCopies() {
+		PitchViewport viewport = viewport(ClientLayout.LANDSCAPE);
+		Rectangle bounds = new Rectangle(145, 0, 782, 452);
+
+		viewport.setViewportBounds(bounds);
+		bounds.x = 999;
+
+		assertEquals(new Rectangle(145, 0, 782, 452), viewport.viewportBounds());
+
+		Rectangle returned = viewport.viewportBounds();
+		returned.x = 999;
+
+		assertEquals(new Rectangle(145, 0, 782, 452), viewport.viewportBounds());
 	}
 }

--- a/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/layout/ClientLayoutCalculatorTest.java
+++ b/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/layout/ClientLayoutCalculatorTest.java
@@ -57,13 +57,40 @@ class ClientLayoutCalculatorTest {
 	}
 
 	@Test
+	void calculatesCurrentSquareBounds() {
+		ClientLayoutResult result = layout(ClientLayout.SQUARE);
+
+		assertEquals(new Rectangle(0, 0, 165, 782), result.homeSidebarBounds());
+		assertEquals(new Rectangle(165, 0, 452, 782), result.fieldBounds());
+		assertEquals(new Rectangle(617, 0, 165, 782), result.awaySidebarBounds());
+		assertEquals(new Rectangle(783, 344, 260, 96), result.scoreBarBounds());
+		assertEquals(new Rectangle(783, 1, 260, 343), result.logBounds());
+		assertEquals(new Rectangle(783, 440, 260, 343), result.chatBounds());
+	}
+
+	@Test
+	void calculatesCurrentWideBounds() {
+		ClientLayoutResult result = layout(ClientLayout.WIDE);
+
+		assertEquals(new Rectangle(0, 0, 145, 1030), result.homeSidebarBounds());
+		assertEquals(new Rectangle(145, 0, 1484, 857), result.fieldBounds());
+		assertEquals(new Rectangle(1631, 0, 145, 1030), result.awaySidebarBounds());
+		assertEquals(new Rectangle(145, 857, 1486, 32), result.scoreBarBounds());
+		assertEquals(new Rectangle(146, 890, 741, 139), result.logBounds());
+		assertEquals(new Rectangle(889, 890, 741, 139), result.chatBounds());		
+	}
+
+	@Test
 	void returnsDefensiveCopies() {
 		ClientLayoutResult result = layout(ClientLayout.LANDSCAPE);
 
 		Dimension preferredSize = result.preferredSize();
 		preferredSize.width = 1;
+		Rectangle fieldBounds = result.fieldBounds();
+		fieldBounds.x = 1;
 
 		assertEquals(new Dimension(1072, 712), result.preferredSize());
+		assertEquals(new Rectangle(145, 0, 782, 452), result.fieldBounds());
 	}
 
 	private ClientLayoutResult layout(ClientLayout layout) {

--- a/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/layout/ClientLayoutCalculatorTest.java
+++ b/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/layout/ClientLayoutCalculatorTest.java
@@ -1,0 +1,74 @@
+package com.fumbbl.ffb.client.layout;
+
+import com.fumbbl.ffb.client.ClientLayout;
+import com.fumbbl.ffb.client.LayoutSettings;
+import com.fumbbl.ffb.client.UiDimensionProvider;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ClientLayoutCalculatorTest {
+
+	@Test
+	void calculatesCurrentLandscapePreferredSize() {
+		assertEquals(new Dimension(1072, 712), layout(ClientLayout.LANDSCAPE).preferredSize());
+	}
+
+	@Test
+	void calculatesCurrentPortraitPreferredSize() {
+		assertEquals(new Dimension(782, 969), layout(ClientLayout.PORTRAIT).preferredSize());
+	}
+
+	@Test
+	void calculatesCurrentSquarePreferredSize() {
+		assertEquals(new Dimension(1044, 784), layout(ClientLayout.SQUARE).preferredSize());
+	}
+
+	@Test
+	void calculatesCurrentWidePreferredSize() {
+		assertEquals(new Dimension(1776, 1030), layout(ClientLayout.WIDE).preferredSize());
+	}
+
+	@Test
+	void calculatesCurrentLandscapeBounds() {
+		ClientLayoutResult result = layout(ClientLayout.LANDSCAPE);
+
+		assertEquals(new Rectangle(0, 0, 145, 712), result.homeSidebarBounds());
+		assertEquals(new Rectangle(145, 0, 782, 452), result.fieldBounds());
+		assertEquals(new Rectangle(145, 452, 782, 32), result.scoreBarBounds());
+		assertEquals(new Rectangle(146, 485, 389, 226), result.logBounds());
+		assertEquals(new Rectangle(537, 485, 389, 226), result.chatBounds());
+		assertEquals(new Rectangle(927, 0, 145, 712), result.awaySidebarBounds());
+	}
+
+	@Test
+	void calculatesCurrentPortraitBounds() {
+		ClientLayoutResult result = layout(ClientLayout.PORTRAIT);
+
+		assertEquals(new Rectangle(0, 0, 165, 782), result.homeSidebarBounds());
+		assertEquals(new Rectangle(165, 0, 452, 782), result.fieldBounds());
+		assertEquals(new Rectangle(617, 0, 165, 782), result.awaySidebarBounds());
+		assertEquals(new Rectangle(0, 782, 782, 32), result.scoreBarBounds());
+		assertEquals(new Rectangle(1, 815, 389, 153), result.logBounds());
+		assertEquals(new Rectangle(392, 815, 389, 153), result.chatBounds());
+	}
+
+	@Test
+	void returnsDefensiveCopies() {
+		ClientLayoutResult result = layout(ClientLayout.LANDSCAPE);
+
+		Dimension preferredSize = result.preferredSize();
+		preferredSize.width = 1;
+
+		assertEquals(new Dimension(1072, 712), result.preferredSize());
+	}
+
+	private ClientLayoutResult layout(ClientLayout layout) {
+		LayoutSettings layoutSettings = new LayoutSettings(layout, 1.0);
+		UiDimensionProvider uiDimensionProvider = new UiDimensionProvider(layoutSettings);
+		return new ClientLayoutCalculator().calculate(uiDimensionProvider);
+	}
+}

--- a/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/util/UtilClientPlayerDragTest.java
+++ b/ffb-client-logic/src/test/java/com/fumbbl/ffb/client/util/UtilClientPlayerDragTest.java
@@ -1,0 +1,98 @@
+package com.fumbbl.ffb.client.util;
+
+import com.fumbbl.ffb.FieldCoordinate;
+import com.fumbbl.ffb.client.ClientLayout;
+import com.fumbbl.ffb.client.FantasyFootballClient;
+import com.fumbbl.ffb.client.LayoutSettings;
+import com.fumbbl.ffb.client.PitchDimensionProvider;
+import com.fumbbl.ffb.client.UiDimensionProvider;
+import com.fumbbl.ffb.client.UserInterface;
+import com.fumbbl.ffb.client.ui.BoxComponent;
+import com.fumbbl.ffb.client.ui.SideBarComponent;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Canvas;
+import java.awt.event.MouseEvent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class UtilClientPlayerDragTest {
+
+	@Test
+	void landscapeFieldModeMapsFieldPixelsToCurrentCoordinates() {
+		assertEquals(new FieldCoordinate(0, 0), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(0, 0), false));
+		assertEquals(new FieldCoordinate(0, 0), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(1, 1), false));
+		assertEquals(new FieldCoordinate(1, 0), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(30, 1), false));
+		assertEquals(new FieldCoordinate(25, 14), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(750, 420), false));
+	}
+
+	@Test
+	void landscapeFieldModePreservesCurrentEdgeAndPaddingBehavior() {
+		assertEquals(new FieldCoordinate(26, 15), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(781, 451), false));
+		assertNull(getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(782, 1), false));
+		assertNull(getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(1, 452), false));
+	}
+
+	@Test
+	void portraitFieldModePreservesCurrentDragMapping() {
+		assertNull(getFieldCoordinate(ClientLayout.PORTRAIT, mouseEventAt(1, 1), false));
+		assertNull(getFieldCoordinate(ClientLayout.PORTRAIT, mouseEventAt(1, 330), false));
+		assertEquals(new FieldCoordinate(15, 0), getFieldCoordinate(ClientLayout.PORTRAIT, mouseEventAt(1, 331), false));
+		assertEquals(new FieldCoordinate(12, 14), getFieldCoordinate(ClientLayout.PORTRAIT, mouseEventAt(420, 420), false));
+		assertEquals(new FieldCoordinate(0, 0), getFieldCoordinate(ClientLayout.PORTRAIT, mouseEventAt(0, 782), false));
+	}
+
+	@Test
+	void boxModeCrossesFromBoxToFieldAfterBoxWidth() {
+		assertEquals(new FieldCoordinate(0, 0), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(145, 0), true));
+		assertEquals(new FieldCoordinate(1, 0), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(175, 1), true));
+		assertEquals(new FieldCoordinate(25, 14), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(895, 420), true));
+	}
+
+	@Test
+	void fieldModeCrossesFromFieldToBoxForNegativeX() {
+		assertEquals(new FieldCoordinate(FieldCoordinate.RSV_HOME_X, 3), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(-1, 0), false));
+		assertEquals(new FieldCoordinate(FieldCoordinate.RSV_HOME_X, 0), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(-145, 0), false));
+		assertNull(getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(-146, 0), false));
+	}
+
+	@Test
+	void boxModeMapsBoxPixelsToReserveCoordinates() {
+		assertEquals(new FieldCoordinate(FieldCoordinate.RSV_HOME_X, 0), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(0, 0), true));
+		assertEquals(new FieldCoordinate(FieldCoordinate.RSV_HOME_X, 1), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(48, 0), true));
+		assertEquals(new FieldCoordinate(FieldCoordinate.RSV_HOME_X, 2), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(96, 0), true));
+		assertEquals(new FieldCoordinate(FieldCoordinate.RSV_HOME_X, 3), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(144, 0), true));
+		assertEquals(new FieldCoordinate(FieldCoordinate.RSV_HOME_X, 3), getFieldCoordinate(ClientLayout.LANDSCAPE, mouseEventAt(0, 48), true));
+	}
+
+	private FieldCoordinate getFieldCoordinate(ClientLayout layout, MouseEvent event, boolean boxMode) {
+		return UtilClientPlayerDrag.getFieldCoordinate(client(layout, 0), event, boxMode);
+	}
+
+	private FantasyFootballClient client(ClientLayout layout, int boxTitleOffset) {
+		LayoutSettings layoutSettings = new LayoutSettings(layout, 1.0);
+		UiDimensionProvider uiDimensionProvider = new UiDimensionProvider(layoutSettings);
+		PitchDimensionProvider pitchDimensionProvider = new PitchDimensionProvider(layoutSettings);
+
+		FantasyFootballClient client = mock(FantasyFootballClient.class);
+		UserInterface userInterface = mock(UserInterface.class);
+		SideBarComponent sideBarHome = mock(SideBarComponent.class);
+		BoxComponent boxComponent = mock(BoxComponent.class);
+
+		given(client.getUserInterface()).willReturn(userInterface);
+		given(userInterface.getUiDimensionProvider()).willReturn(uiDimensionProvider);
+		given(userInterface.getPitchDimensionProvider()).willReturn(pitchDimensionProvider);
+		given(userInterface.getSideBarHome()).willReturn(sideBarHome);
+		given(sideBarHome.getBoxComponent()).willReturn(boxComponent);
+		given(boxComponent.getMaxTitleOffset()).willReturn(boxTitleOffset);
+
+		return client;
+	}
+
+	private MouseEvent mouseEventAt(int x, int y) {
+		return new MouseEvent(new Canvas(), MouseEvent.MOUSE_MOVED, 0, 0, x, y, 0, false);
+	}
+}

--- a/ffb-client/src/main/java/com/fumbbl/ffb/client/state/ClientStateAwt.java
+++ b/ffb-client/src/main/java/com/fumbbl/ffb/client/state/ClientStateAwt.java
@@ -39,6 +39,7 @@ public abstract class ClientStateAwt<T extends LogicModule> extends ClientState<
 
 	private boolean fClickable;
 	private final PitchDimensionProvider pitchDimensionProvider;
+	private final PitchViewport pitchViewport;
 	private JPopupMenu fPopupMenu;
 	private int popupIndex;
 	private List<JPopupMenu> popupMenus;
@@ -54,6 +55,7 @@ public abstract class ClientStateAwt<T extends LogicModule> extends ClientState<
 		setClickable(true);
 		pitchDimensionProvider = pClient.getUserInterface().getPitchDimensionProvider();
 		coordinateConverter = pClient.getUserInterface().getCoordinateConverter();
+		pitchViewport = pClient.getUserInterface().getPitchViewport();
 	}
 
 	public void setUp() {
@@ -108,12 +110,11 @@ public abstract class ClientStateAwt<T extends LogicModule> extends ClientState<
 		if (pCoordinate != null) {
 			FieldComponent fieldComponent = getClient().getUserInterface().getFieldComponent();
 
-			Dimension dimension = pitchDimensionProvider.mapToLocal(pCoordinate);
+			Dimension dimension = pitchViewport.toLocal(pCoordinate);
 			int x = dimension.width + 1;
 			int y = dimension.height + 1;
 			Rectangle bounds =
-				new Rectangle(x, y, pitchDimensionProvider.fieldSquareSize() - 2,
-					pitchDimensionProvider.fieldSquareSize() - 2);
+				new Rectangle(x, y, pitchViewport.squareSize() - 2, pitchViewport.squareSize() - 2);
 
 			Graphics2D g2d = fieldComponent.getImage().createGraphics();
 			g2d.setPaint(pColor);
@@ -133,9 +134,9 @@ public abstract class ClientStateAwt<T extends LogicModule> extends ClientState<
 
 	private void clearCoordinate(FieldCoordinate coordinate) {
 		FieldComponent fieldComponent = getClient().getUserInterface().getFieldComponent();
-		Dimension dimension = pitchDimensionProvider.mapToLocal(coordinate);
-		Rectangle bounds = new Rectangle(dimension.width, dimension.height, pitchDimensionProvider.fieldSquareSize(),
-			pitchDimensionProvider.fieldSquareSize());
+		Dimension dimension = pitchViewport.toLocal(coordinate);
+		Rectangle bounds = new Rectangle(dimension.width, dimension.height, pitchViewport.squareSize(),
+			pitchViewport.squareSize());
 		fieldComponent.refresh(bounds);
 	}
 
@@ -181,7 +182,7 @@ public abstract class ClientStateAwt<T extends LogicModule> extends ClientState<
 				}
 
 				Dimension dimension =
-					pitchDimensionProvider.mapToLocal(coordinate.getX() + offsetX, coordinate.getY() + offsetY, false);
+					pitchViewport.toLocal(coordinate.getX() + offsetX, coordinate.getY() + offsetY, false);
 
 				if (player.isPresent()) {
 					getClient().getUserInterface().getMarkerService()
@@ -251,7 +252,7 @@ public abstract class ClientStateAwt<T extends LogicModule> extends ClientState<
 					offsetX = -1;
 				}
 				Dimension dimension =
-					pitchDimensionProvider.mapToLocal(coordinate.getX() + offsetX, coordinate.getY() + offsetY, false);
+					pitchViewport.toLocal(coordinate.getX() + offsetX, coordinate.getY() + offsetY, false);
 				fPopupMenu.show(getClient().getUserInterface().getFieldComponent(), dimension.width, dimension.height);
 				menuOpen = true;
 			}


### PR DESCRIPTION
## Summary

Adds the Phase 7 viewport transform work from `docs/fullscreen-layout-plan.md`.

`PitchViewport` now stores the calculated pitch viewport bounds from the fixed layout result and exposes content-coordinate transform methods:

- `worldToScreen(...)`
- `screenToWorld(...)`

The existing local-coordinate methods remain in place:

- `toLocal(...)`
- `toFieldCoordinate(...)`

Those are still used for field-component-local rendering/input. The new transform methods are for client content coordinates, where the pitch position inside `ClientLayoutPanel` matters.

This also migrates `DialogPlayerChoice` away from manually adding the sidebar width and uses `worldToScreen(...)` instead.