### PR TITLE
Fix carried-player placement after carrier removal

### DIFF
--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/ActiveEffects.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/ActiveEffects.java
@@ -95,9 +95,10 @@ public class ActiveEffects implements IJsonSerializable {
 	}
 
 	public void setCarriedPlayer(String carriedPlayerId, PlayerState oldCarriedPlayerState,
-		FieldCoordinate oldCarriedPlayerCoordinate, boolean carriedPlayerHasBall) {
+		FieldCoordinate oldCarriedPlayerCoordinate, boolean carriedPlayerHasBall, FieldCoordinate carrierCoordinate) {
 		this.carriedPlayer =
-			new CarriedPlayer(carriedPlayerId, oldCarriedPlayerState, oldCarriedPlayerCoordinate, carriedPlayerHasBall);
+			new CarriedPlayer(carriedPlayerId, oldCarriedPlayerState, oldCarriedPlayerCoordinate, carriedPlayerHasBall,
+				carrierCoordinate);
 	}
 
 	@Override
@@ -144,6 +145,7 @@ public class ActiveEffects implements IJsonSerializable {
 			IServerJsonOption.OLD_CARRIED_PLAYER_STATE.addTo(jsonObject, carriedPlayer.getOldState());
 			IServerJsonOption.OLD_CARRIED_PLAYER_COORDINATE.addTo(jsonObject, carriedPlayer.getOldCoordinate());
 			IServerJsonOption.CARRIED_PLAYER_HAS_BALL.addTo(jsonObject, carriedPlayer.hasBall());
+			IServerJsonOption.CARRIER_COORDINATE.addTo(jsonObject, carriedPlayer.getCarrierCoordinate());
 		}
 		return jsonObject;
 	}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/GameState.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/GameState.java
@@ -419,8 +419,9 @@ public class GameState implements IModelChangeObserver, IJsonSerializable {
 	}
 
 	public void setCarriedPlayer(String carriedPlayerId, PlayerState oldCarriedPlayerState,
-		FieldCoordinate oldCarriedPlayerCoordinate, boolean carriedPlayerHasBall) {
-		activeEffects.setCarriedPlayer(carriedPlayerId, oldCarriedPlayerState, oldCarriedPlayerCoordinate, carriedPlayerHasBall);
+		FieldCoordinate oldCarriedPlayerCoordinate, boolean carriedPlayerHasBall, FieldCoordinate carrierCoordinate) {
+		activeEffects.setCarriedPlayer(carriedPlayerId, oldCarriedPlayerState, oldCarriedPlayerCoordinate, carriedPlayerHasBall,
+			carrierCoordinate);
 	}
 
 	public void clearCarriedPlayer() {

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/IServerJsonOption.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/IServerJsonOption.java
@@ -48,6 +48,7 @@ public interface IServerJsonOption extends IJsonOption {
     JsonBooleanOption CARDS_SELECTED_HOME = new JsonBooleanOption("cardsSelectedHome");
     JsonBooleanOption CARRIED_PLAYER_HAS_BALL = new JsonBooleanOption("carriedPlayerHasBall");
     JsonStringOption CARRIED_PLAYER_ID = new JsonStringOption("carriedPlayerId");
+    JsonFieldCoordinateOption CARRIER_COORDINATE = new JsonFieldCoordinateOption("carrierCoordinate");
     JsonEnumWithNameOption CATCH_SCATTER_THROW_IN_MODE = new JsonEnumWithNameOption("catchScatterThrowInMode",
       Factory.CATCH_SCATTER_THROWIN_MODE);
     JsonBooleanOption CHECK_FORGO = new JsonBooleanOption("checkForgo");

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/model/CarriedPlayer.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/model/CarriedPlayer.java
@@ -21,11 +21,12 @@ public class CarriedPlayer implements IJsonSerializable {
 	}
 
 	public CarriedPlayer(String playerId, PlayerState oldState, FieldCoordinate oldCoordinate,
-		boolean hasBall) {
+		boolean hasBall, FieldCoordinate carrierCoordinate) {
 		this.playerId = playerId;
 		this.oldState = oldState;
 		this.oldCoordinate = oldCoordinate;
 		this.hasBall = hasBall;
+		this.carrierCoordinate = carrierCoordinate;
 	}
 
 	public String getPlayerId() {

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/model/CarriedPlayer.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/model/CarriedPlayer.java
@@ -15,11 +15,13 @@ public class CarriedPlayer implements IJsonSerializable {
 	private PlayerState oldState;
 	private FieldCoordinate oldCoordinate;
 	private boolean hasBall;
+	private FieldCoordinate carrierCoordinate;
 
 	public CarriedPlayer() {
 	}
 
-	public CarriedPlayer(String playerId, PlayerState oldState, FieldCoordinate oldCoordinate, boolean hasBall) {
+	public CarriedPlayer(String playerId, PlayerState oldState, FieldCoordinate oldCoordinate,
+		boolean hasBall) {
 		this.playerId = playerId;
 		this.oldState = oldState;
 		this.oldCoordinate = oldCoordinate;
@@ -42,6 +44,14 @@ public class CarriedPlayer implements IJsonSerializable {
 		return hasBall;
 	}
 
+	public FieldCoordinate getCarrierCoordinate() {
+		return carrierCoordinate;
+	}
+
+	public void setCarrierCoordinate(FieldCoordinate carrierCoordinate) {
+		this.carrierCoordinate = carrierCoordinate;
+	}
+
 	@Override
 	public CarriedPlayer initFrom(IFactorySource source, JsonValue jsonValue) {
 		JsonObject jsonObject = UtilJson.toJsonObject(jsonValue);
@@ -49,6 +59,7 @@ public class CarriedPlayer implements IJsonSerializable {
 		oldState = IServerJsonOption.OLD_CARRIED_PLAYER_STATE.getFrom(source, jsonObject);
 		oldCoordinate = IServerJsonOption.OLD_CARRIED_PLAYER_COORDINATE.getFrom(source, jsonObject);
 		hasBall = IServerJsonOption.CARRIED_PLAYER_HAS_BALL.getFrom(source, jsonObject);
+		carrierCoordinate = IServerJsonOption.CARRIER_COORDINATE.getFrom(source, jsonObject);
 		return this;
 	}
 
@@ -59,6 +70,7 @@ public class CarriedPlayer implements IJsonSerializable {
 		IServerJsonOption.OLD_CARRIED_PLAYER_STATE.addTo(jsonObject, oldState);
 		IServerJsonOption.OLD_CARRIED_PLAYER_COORDINATE.addTo(jsonObject, oldCoordinate);
 		IServerJsonOption.CARRIED_PLAYER_HAS_BALL.addTo(jsonObject, hasBall);
+		IServerJsonOption.CARRIER_COORDINATE.addTo(jsonObject, carrierCoordinate);
 		return jsonObject;
 	}
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/model/change/CarriedPlayerCoordinateObserver.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/model/change/CarriedPlayerCoordinateObserver.java
@@ -27,7 +27,7 @@ public class CarriedPlayerCoordinateObserver implements ConditionalModelChangeOb
 			case FIELD_MODEL_SET_PLAYER_COORDINATE:
 			case FIELD_MODEL_REMOVE_PLAYER:
 				FieldCoordinate coordinate = (FieldCoordinate) modelChange.getValue();
-				if (!coordinate.isBoxCoordinate()) {
+				if (coordinate != null && !coordinate.isBoxCoordinate()) {
 					carriedPlayer.setCarrierCoordinate(coordinate);
 				}
 				break;

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/model/change/CarriedPlayerCoordinateObserver.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/model/change/CarriedPlayerCoordinateObserver.java
@@ -1,0 +1,38 @@
+package com.fumbbl.ffb.server.model.change;
+
+import com.fumbbl.ffb.FieldCoordinate;
+import com.fumbbl.ffb.RulesCollection;
+import com.fumbbl.ffb.model.change.ModelChange;
+import com.fumbbl.ffb.server.GameState;
+import com.fumbbl.ffb.server.model.CarriedPlayer;
+import com.fumbbl.ffb.util.StringTool;
+
+@RulesCollection(RulesCollection.Rules.BB2025)
+public class CarriedPlayerCoordinateObserver implements ConditionalModelChangeObserver {
+
+	@Override
+	public void next(GameState gameState, ModelChange modelChange) {
+
+		String key = modelChange.getKey();
+		if (!StringTool.isProvided(key)) {
+			return;
+		}
+		CarriedPlayer carriedPlayer = gameState.getCarriedPlayer();
+
+		if (carriedPlayer == null || !gameState.getGame().getActingPlayer().getPlayerId().equals(modelChange.getKey())) {
+			return;
+		}
+
+		switch (modelChange.getChangeId()) {
+			case FIELD_MODEL_SET_PLAYER_COORDINATE:
+			case FIELD_MODEL_REMOVE_PLAYER:
+				FieldCoordinate coordinate = (FieldCoordinate) modelChange.getValue();
+				if (!coordinate.isBoxCoordinate()) {
+					carriedPlayer.setCarrierCoordinate(coordinate);
+				}
+				break;
+			default:
+				break;
+		}
+	}
+}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepIllCarryYou.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepIllCarryYou.java
@@ -157,7 +157,8 @@ public class StepIllCarryYou extends AbstractStep {
 		boolean carriedPlayerHasBall = UtilPlayer.hasBall(game, carriedPlayer);
 
 		gameState.setCarriedPlayer(carriedPlayer.getId(), game.getFieldModel().getPlayerState(carriedPlayer),
-			game.getFieldModel().getPlayerCoordinate(carriedPlayer), carriedPlayerHasBall);
+			game.getFieldModel().getPlayerCoordinate(carriedPlayer), carriedPlayerHasBall,
+			game.getFieldModel().getPlayerCoordinate(carrier));
 
 		game.getFieldModel().setPlayerState(carriedPlayer,
 			game.getFieldModel().getPlayerState(carriedPlayer).changeBase(PlayerState.PICKED_UP));

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepPlaceCarriedPlayer.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepPlaceCarriedPlayer.java
@@ -123,10 +123,7 @@ public class StepPlaceCarriedPlayer extends AbstractStep {
 
 		Player<?> carrier = actingPlayer.getPlayer();
 		Player<?> carriedPlayer = game.getPlayerById(carriedPlayerState.getPlayerId());
-		FieldCoordinate carrierCoordinate = game.getFieldModel().getPlayerCoordinate(carrier);
-		if (carrierCoordinate.isBoxCoordinate()) {
-			carrierCoordinate = carriedPlayerState.getCarrierCoordinate();
-		}
+		FieldCoordinate carrierCoordinate = carriedPlayerState.getCarrierCoordinate();
 		PlayerState carrierState = game.getFieldModel().getPlayerState(carrier);
 
 		if (!actingPlayer.hasActedIgnoringNegativeTraits()

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepPlaceCarriedPlayer.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepPlaceCarriedPlayer.java
@@ -124,6 +124,9 @@ public class StepPlaceCarriedPlayer extends AbstractStep {
 		Player<?> carrier = actingPlayer.getPlayer();
 		Player<?> carriedPlayer = game.getPlayerById(carriedPlayerState.getPlayerId());
 		FieldCoordinate carrierCoordinate = game.getFieldModel().getPlayerCoordinate(carrier);
+		if (carrierCoordinate.isBoxCoordinate()) {
+			carrierCoordinate = carriedPlayerState.getCarrierCoordinate();
+		}
 		PlayerState carrierState = game.getFieldModel().getPlayerState(carrier);
 
 		if (!actingPlayer.hasActedIgnoringNegativeTraits()


### PR DESCRIPTION
I'll Carry You now tracks the carrier's last pitch coordinate while carrying, so placement/bounce can still resolve from the correct square if the carrier is removed first, such as after a failed jump/rush or ejection.
