### PR TITLE
Fix TTM duplicate selection after moving

### DIFF
--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/ttm/StepInitThrowTeamMate.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/ttm/StepInitThrowTeamMate.java
@@ -105,10 +105,17 @@ public final class StepInitThrowTeamMate extends AbstractStep {
 							targetCoordinate = game.isHomePlaying() ? throwTeamMateCommand.getTargetCoordinate()
 								: throwTeamMateCommand.getTargetCoordinate().transform();
 							commandStatus = StepCommandStatus.EXECUTE_STEP;
-						} else if (!StringTool.isProvided(thrownPlayerId)) {
-							thrownPlayerId = throwTeamMateCommand.getThrownPlayerId();
-							targetCoordinate = null;
-							commandStatus = StepCommandStatus.EXECUTE_STEP;
+						} else if (StringTool.isProvided(throwTeamMateCommand.getThrownPlayerId())) {
+							PlayerState thrownPlayerState =
+								game.getFieldModel().getPlayerState(game.getPlayerById(throwTeamMateCommand.getThrownPlayerId()));
+
+							if (thrownPlayerState.getBase() == PlayerState.PICKED_UP) {
+								commandStatus = StepCommandStatus.SKIP_STEP;
+							} else {
+								thrownPlayerId = throwTeamMateCommand.getThrownPlayerId();
+								targetCoordinate = null;
+								commandStatus = StepCommandStatus.EXECUTE_STEP;
+							}
 						}
 					}
 					break;


### PR DESCRIPTION
The previous guard skipped the forwarded player-click because `thrownPlayerId` was already set by the move step. This now only skips the command if that player is already `PICKED_UP`, which keeps the double-click fix but lets move-then-TTM work again.

Tested both no-move double-click TTM and move-then-TTM.