### PR TITLE
Fix Taunt after POW results

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -9,6 +9,11 @@ public class ChangeList {
 	private final List<VersionChangeList> versions = new ArrayList<>();
 
 	public ChangeList() {
+
+		versions.add(new VersionChangeList("3.3.2")
+			.addBugfix("Taunt: Was not available after POW results")
+		);
+
 		versions.add(new VersionChangeList("3.3.1")
 			.addBugfix("Hatred: Game hung on hovers on players with gained hatred only")
 		);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepFollowup.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/block/StepFollowup.java
@@ -166,7 +166,8 @@ public class StepFollowup extends AbstractStep {
 			}
 			Skill skillForcesFollowup = game.getDefender().getSkillWithProperty(NamedProperties.forceOpponentToFollowUp);
 			boolean cannotFollow = attackerState.isPinned() || actingPlayer.getPlayerAction() == PlayerAction.VICIOUS_VINES || actingPlayer.getPlayerAction() == PlayerAction.MULTIPLE_BLOCK;
-			if (game.getDefender().hasUsableSkillProperty(NamedProperties.forceOpponentToFollowUp, defenderState) && followupChoice == null && usingSkillPreventingFollowUp != null && !usingSkillPreventingFollowUp && !cannotFollow) {
+			if (skillForcesFollowup != null && !defenderState.isDistracted() && followupChoice == null
+					&& usingSkillPreventingFollowUp != null && !usingSkillPreventingFollowUp && !cannotFollow) {
 				if (usingSkillForcingFollowUp == null) {
 					UtilServerDialog.showDialog(getGameState(), new DialogSkillUseParameter(game.getDefenderId(), skillForcesFollowup, 0), true);
 					return;


### PR DESCRIPTION
Fixes a Taunt regression where Taunt was not offered after a POW result.

The defender state is already changed to falling before follow-up handling, so the Taunt check now avoids requiring the defender to still be standing while still blocking use when distracted.