### PR TITLE
Fix BB2025 wizard targeting and Fireball effects

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogConfirmWizardFriendlyFire.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogConfirmWizardFriendlyFire.java
@@ -1,0 +1,19 @@
+package com.fumbbl.ffb.client.dialog;
+
+import com.fumbbl.ffb.SpecialEffect;
+import com.fumbbl.ffb.client.FantasyFootballClient;
+import com.fumbbl.ffb.dialog.DialogId;
+
+public class DialogConfirmWizardFriendlyFire extends DialogThreeWayChoice {
+
+	public DialogConfirmWizardFriendlyFire(FantasyFootballClient pClient, SpecialEffect pWizardSpell) {
+		super(pClient, "Confirm Wizard Spell", new String[]{
+			pWizardSpell.getName() + " will affect one or more of your own players.",
+			"Do you want to cast it anyway?"
+		}, null);
+	}
+
+	public DialogId getId() {
+		return DialogId.YES_OR_NO_QUESTION;
+	}
+}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -13,6 +13,7 @@ public class ChangeList {
 		versions.add(new VersionChangeList("3.3.2")
 			.addBugfix("Taunt: Was not available after POW results")
 			.addBugfix("Bombardier: The bomber could be activated again when the bomb was caught or intercepted and thrown by another player")
+			.addBugfix("Wizard: Fireball did not affect prone or stunned players, and Fireball/Zap could not target own-team players in the 2025 ruleset")
 		);
 
 		versions.add(new VersionChangeList("3.3.1")

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/bb2025/WizardLogicModule.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/bb2025/WizardLogicModule.java
@@ -1,0 +1,163 @@
+package com.fumbbl.ffb.client.state.logic.bb2025;
+
+import com.fumbbl.ffb.ClientStateId;
+import com.fumbbl.ffb.FieldCoordinate;
+import com.fumbbl.ffb.FieldCoordinateBounds;
+import com.fumbbl.ffb.PlayerState;
+import com.fumbbl.ffb.SpecialEffect;
+import com.fumbbl.ffb.client.FantasyFootballClient;
+import com.fumbbl.ffb.client.state.logic.ClientAction;
+import com.fumbbl.ffb.client.state.logic.LogicModule;
+import com.fumbbl.ffb.client.state.logic.interaction.ActionContext;
+import com.fumbbl.ffb.client.state.logic.interaction.InteractionResult;
+import com.fumbbl.ffb.model.ActingPlayer;
+import com.fumbbl.ffb.model.Game;
+import com.fumbbl.ffb.model.Player;
+import com.fumbbl.ffb.model.RosterPlayer;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ *
+ * @author Kalimar
+ */
+public class WizardLogicModule extends LogicModule {
+
+	private boolean spellAvailable;
+
+	public WizardLogicModule(FantasyFootballClient pClient) {
+		super(pClient);
+	}
+
+	public ClientStateId getId() {
+		return ClientStateId.WIZARD;
+	}
+
+	@Override
+	public void setUp() {
+		super.setUp();
+		spellAvailable = true;
+	}
+
+	@Override
+	public InteractionResult fieldPeek(FieldCoordinate pCoordinate) {
+		SpecialEffect wizardSpell = client.getClientData().getWizardSpell();
+		if ((pCoordinate != null) && (wizardSpell != null)) {
+			return determineSpecialEffect(pCoordinate);
+		} else {
+			return super.fieldPeek(pCoordinate);
+		}
+	}
+
+	@Override
+	public InteractionResult playerPeek(Player<?> pPlayer) {
+		SpecialEffect wizardSpell = client.getClientData().getWizardSpell();
+		FieldCoordinate playerCoordinate = client.getGame().getFieldModel().getPlayerCoordinate(pPlayer);
+		if ((playerCoordinate != null) && (wizardSpell != null)) {
+			return determineSpecialEffect(playerCoordinate);
+		} else {
+			return super.playerPeek(pPlayer);
+		}
+	}
+
+	private InteractionResult determineSpecialEffect(FieldCoordinate pCoordinate) {
+		if (spellAvailable) {
+			SpecialEffect wizardSpell = client.getClientData().getWizardSpell();
+			return InteractionResult.perform().with(pCoordinate).with(wizardSpell);
+		}
+		return InteractionResult.ignore();
+	}
+
+	@Override
+	public InteractionResult fieldInteraction(FieldCoordinate pCoordinate) {
+		return handleClick(pCoordinate);
+	}
+
+	@Override
+	public InteractionResult playerInteraction(Player<?> pPlayer) {
+		FieldCoordinate playerCoordinate = client.getGame().getFieldModel().getPlayerCoordinate(pPlayer);
+		return handleClick(playerCoordinate);
+	}
+
+	private InteractionResult handleClick(FieldCoordinate pCoordinate) {
+		if (pCoordinate != null) {
+			SpecialEffect wizardSpell = client.getClientData().getWizardSpell();
+			if (SpecialEffect.LIGHTNING == wizardSpell) {
+				if (isValidLightningTarget(pCoordinate)) {
+					client.getCommunication().sendWizardSpell(wizardSpell, pCoordinate);
+					spellAvailable = false;
+					return InteractionResult.handled();
+				} else {
+					return InteractionResult.reset();
+				}
+			}
+			if (SpecialEffect.ZAP == wizardSpell) {
+				if (isValidZapTarget(pCoordinate)) {
+					client.getCommunication().sendWizardSpell(wizardSpell, pCoordinate);
+					spellAvailable = false;
+					return InteractionResult.handled();
+				} else {
+					return InteractionResult.reset();
+				}
+			}
+			if (SpecialEffect.FIREBALL == wizardSpell) {
+				if (isValidFireballTarget(pCoordinate)) {
+					client.getCommunication().sendWizardSpell(wizardSpell, pCoordinate);
+					spellAvailable = false;
+					return InteractionResult.handled();
+				} else {
+					return InteractionResult.reset();
+				}
+			}
+		}
+		return InteractionResult.ignore();
+	}
+
+
+	public boolean isValidLightningTarget(FieldCoordinate pCoordinate) {
+		boolean valid = false;
+		Game game = client.getGame();
+		Player<?> player = game.getFieldModel().getPlayer(pCoordinate);
+		if ((player != null) && game.getTeamAway().hasPlayer(player)) {
+			PlayerState playerState = game.getFieldModel().getPlayerState(player);
+			valid = ((playerState.getBase() != PlayerState.STUNNED) && (playerState.getBase() != PlayerState.PRONE));
+		}
+		return valid;
+	}
+
+	public boolean isValidZapTarget(FieldCoordinate pCoordinate) {
+		Game game = client.getGame();
+		Player<?> player = game.getFieldModel().getPlayer(pCoordinate);
+		return player instanceof RosterPlayer;
+	}
+
+	public boolean isValidFireballTarget(FieldCoordinate pCoordinate) {
+		boolean valid = false;
+		Game game = client.getGame();
+		FieldCoordinate[] fireballSquares = game.getFieldModel().findAdjacentCoordinates(pCoordinate,
+				FieldCoordinateBounds.FIELD, 1, true);
+		for (FieldCoordinate square : fireballSquares) {
+			Player<?> player = game.getFieldModel().getPlayer(square);
+			if ((player != null) && (game.getFieldModel().getPlayerState(player) != null)) {
+				return true;
+			}
+		}
+		return valid;
+	}
+
+	@Override
+	public Set<ClientAction> availableActions() {
+		return Collections.emptySet();
+	}
+	@Override
+	protected void performAvailableAction(Player<?> player, ClientAction action) {
+
+	}
+
+	@Override
+	protected ActionContext actionContext(ActingPlayer actingPlayer) {
+		throw new UnsupportedOperationException("actionContext for acting player is not supported in wizard context");
+	}
+
+}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/bb2025/WizardLogicModule.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/bb2025/WizardLogicModule.java
@@ -3,7 +3,6 @@ package com.fumbbl.ffb.client.state.logic.bb2025;
 import com.fumbbl.ffb.ClientStateId;
 import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.FieldCoordinateBounds;
-import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.SpecialEffect;
 import com.fumbbl.ffb.client.FantasyFootballClient;
 import com.fumbbl.ffb.client.state.logic.ClientAction;
@@ -83,15 +82,6 @@ public class WizardLogicModule extends LogicModule {
 	private InteractionResult handleClick(FieldCoordinate pCoordinate) {
 		if (pCoordinate != null) {
 			SpecialEffect wizardSpell = client.getClientData().getWizardSpell();
-			if (SpecialEffect.LIGHTNING == wizardSpell) {
-				if (isValidLightningTarget(pCoordinate)) {
-					client.getCommunication().sendWizardSpell(wizardSpell, pCoordinate);
-					spellAvailable = false;
-					return InteractionResult.handled();
-				} else {
-					return InteractionResult.reset();
-				}
-			}
 			if (SpecialEffect.ZAP == wizardSpell) {
 				if (isValidZapTarget(pCoordinate)) {
 					client.getCommunication().sendWizardSpell(wizardSpell, pCoordinate);
@@ -112,18 +102,6 @@ public class WizardLogicModule extends LogicModule {
 			}
 		}
 		return InteractionResult.ignore();
-	}
-
-
-	public boolean isValidLightningTarget(FieldCoordinate pCoordinate) {
-		boolean valid = false;
-		Game game = client.getGame();
-		Player<?> player = game.getFieldModel().getPlayer(pCoordinate);
-		if ((player != null) && game.getTeamAway().hasPlayer(player)) {
-			PlayerState playerState = game.getFieldModel().getPlayerState(player);
-			valid = ((playerState.getBase() != PlayerState.STUNNED) && (playerState.getBase() != PlayerState.PRONE));
-		}
-		return valid;
 	}
 
 	public boolean isValidZapTarget(FieldCoordinate pCoordinate) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/bb2025/WizardLogicModule.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/bb2025/WizardLogicModule.java
@@ -111,17 +111,34 @@ public class WizardLogicModule extends LogicModule {
 	}
 
 	public boolean isValidFireballTarget(FieldCoordinate pCoordinate) {
-		boolean valid = false;
+		return fireballAffectsPlayer(pCoordinate, false);
+	}
+
+	private boolean fireballAffectsPlayer(FieldCoordinate pCoordinate, boolean pOwnTeamOnly) {
 		Game game = client.getGame();
 		FieldCoordinate[] fireballSquares = game.getFieldModel().findAdjacentCoordinates(pCoordinate,
-				FieldCoordinateBounds.FIELD, 1, true);
+			FieldCoordinateBounds.FIELD, 1, true);
 		for (FieldCoordinate square : fireballSquares) {
 			Player<?> player = game.getFieldModel().getPlayer(square);
-			if ((player != null) && (game.getFieldModel().getPlayerState(player) != null)) {
+			if ((player != null)
+				&& (!pOwnTeamOnly || game.getTeamHome().hasPlayer(player))
+				&& (game.getFieldModel().getPlayerState(player) != null)) {
 				return true;
 			}
 		}
-		return valid;
+		return false;
+	}
+
+	public boolean affectsOwnPlayer(FieldCoordinate pCoordinate, SpecialEffect pWizardSpell) {
+		Game game = client.getGame();
+		if (SpecialEffect.ZAP == pWizardSpell) {
+			Player<?> player = game.getFieldModel().getPlayer(pCoordinate);
+			return (player instanceof RosterPlayer) && game.getTeamHome().hasPlayer(player);
+		}
+		if (SpecialEffect.FIREBALL == pWizardSpell) {
+			return fireballAffectsPlayer(pCoordinate, true);
+		}
+		return false;
 	}
 
 	@Override

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/mixed/WizardLogicModule.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/logic/mixed/WizardLogicModule.java
@@ -1,7 +1,9 @@
-package com.fumbbl.ffb.client.state.logic;
+package com.fumbbl.ffb.client.state.logic.mixed;
 
 import com.fumbbl.ffb.*;
 import com.fumbbl.ffb.client.FantasyFootballClient;
+import com.fumbbl.ffb.client.state.logic.ClientAction;
+import com.fumbbl.ffb.client.state.logic.LogicModule;
 import com.fumbbl.ffb.client.state.logic.interaction.ActionContext;
 import com.fumbbl.ffb.client.state.logic.interaction.InteractionResult;
 import com.fumbbl.ffb.model.ActingPlayer;

--- a/ffb-client/src/main/java/com/fumbbl/ffb/client/state/bb2025/ClientStateWizard.java
+++ b/ffb-client/src/main/java/com/fumbbl/ffb/client/state/bb2025/ClientStateWizard.java
@@ -63,11 +63,6 @@ public class ClientStateWizard extends ClientStateAwt<WizardLogicModule> {
 	private void drawSpellmarker(FieldCoordinate pCoordinate, SpecialEffect wizardSpell) {
 		FieldComponent fieldComponent = getClient().getUserInterface().getFieldComponent();
 		switch (wizardSpell) {
-			case LIGHTNING:
-				fieldComponent.getLayerOverPlayers().clearSpellMarker();
-				fieldComponent.getLayerOverPlayers().drawSpellMarker(pCoordinate, IIconProperty.GAME_LIGHTNING_SMALL,
-					!logicModule.isValidLightningTarget(pCoordinate));
-				break;
 			case ZAP:
 				fieldComponent.getLayerOverPlayers().clearSpellMarker();
 				fieldComponent.getLayerOverPlayers().drawSpellMarker(pCoordinate, IIconProperty.GAME_ZAP_SMALL,

--- a/ffb-client/src/main/java/com/fumbbl/ffb/client/state/bb2025/ClientStateWizard.java
+++ b/ffb-client/src/main/java/com/fumbbl/ffb/client/state/bb2025/ClientStateWizard.java
@@ -6,6 +6,9 @@ import com.fumbbl.ffb.RulesCollection;
 import com.fumbbl.ffb.SpecialEffect;
 import com.fumbbl.ffb.client.FantasyFootballClientAwt;
 import com.fumbbl.ffb.client.FieldComponent;
+import com.fumbbl.ffb.client.dialog.DialogConfirmWizardFriendlyFire;
+import com.fumbbl.ffb.client.dialog.IDialog;
+import com.fumbbl.ffb.client.dialog.IDialogCloseListener;
 import com.fumbbl.ffb.client.state.ClientStateAwt;
 import com.fumbbl.ffb.client.state.logic.ClientAction;
 import com.fumbbl.ffb.client.state.logic.interaction.InteractionResult;
@@ -19,7 +22,9 @@ import java.util.Map;
  * @author Kalimar
  */
 @RulesCollection(RulesCollection.Rules.BB2025)
-public class ClientStateWizard extends ClientStateAwt<WizardLogicModule> {
+public class ClientStateWizard extends ClientStateAwt<WizardLogicModule> implements IDialogCloseListener {
+
+	private FieldCoordinate pendingCoordinate;
 
 	public ClientStateWizard(FantasyFootballClientAwt pClient) {
 		super(pClient, new WizardLogicModule(pClient));
@@ -78,6 +83,10 @@ public class ClientStateWizard extends ClientStateAwt<WizardLogicModule> {
 
 	@Override
 	public void clickOnField(FieldCoordinate pCoordinate) {
+		if (showFriendlyFireConfirmation(pCoordinate)) {
+			return;
+		}
+
 		InteractionResult result = logicModule.fieldInteraction(pCoordinate);
 		switch (result.getKind()) {
 			case RESET:
@@ -104,6 +113,11 @@ public class ClientStateWizard extends ClientStateAwt<WizardLogicModule> {
 
 	@Override
 	public void clickOnPlayer(Player<?> pPlayer) {
+		FieldCoordinate playerCoordinate = getClient().getGame().getFieldModel().getPlayerCoordinate(pPlayer);
+		if (showFriendlyFireConfirmation(playerCoordinate)) {
+			return;
+		}
+
 		InteractionResult result = logicModule.playerInteraction(pPlayer);
 		switch (result.getKind()) {
 			case RESET:
@@ -124,9 +138,34 @@ public class ClientStateWizard extends ClientStateAwt<WizardLogicModule> {
 		getClient().getUserInterface().getDialogManager().updateDialog();
 	}
 
+	private boolean showFriendlyFireConfirmation(FieldCoordinate pCoordinate) {
+		SpecialEffect wizardSpell = getClient().getClientData().getWizardSpell();
+		if (!logicModule.affectsOwnPlayer(pCoordinate, wizardSpell)) {
+			return false;
+		}
+
+		pendingCoordinate = pCoordinate;
+		new DialogConfirmWizardFriendlyFire(getClient(), wizardSpell).showDialog(this);
+		return true;
+	}
 
 	@Override
 	protected Map<Integer, ClientAction> actionMapping(int menuIndex) {
 		return Collections.emptyMap();
+	}
+
+	@Override
+	public void dialogClosed(IDialog pDialog) {
+		pDialog.hideDialog();
+
+		if (((DialogConfirmWizardFriendlyFire) pDialog).isChoiceYes()) {
+			logicModule.fieldInteraction(pendingCoordinate);
+			clearMarker();
+		} else {
+			clearMarker();
+			redisplaySpellDialog();
+		}
+
+		pendingCoordinate = null;
 	}
 }

--- a/ffb-client/src/main/java/com/fumbbl/ffb/client/state/bb2025/ClientStateWizard.java
+++ b/ffb-client/src/main/java/com/fumbbl/ffb/client/state/bb2025/ClientStateWizard.java
@@ -1,0 +1,137 @@
+package com.fumbbl.ffb.client.state.bb2025;
+
+import com.fumbbl.ffb.FieldCoordinate;
+import com.fumbbl.ffb.IIconProperty;
+import com.fumbbl.ffb.RulesCollection;
+import com.fumbbl.ffb.SpecialEffect;
+import com.fumbbl.ffb.client.FantasyFootballClientAwt;
+import com.fumbbl.ffb.client.FieldComponent;
+import com.fumbbl.ffb.client.state.ClientStateAwt;
+import com.fumbbl.ffb.client.state.logic.ClientAction;
+import com.fumbbl.ffb.client.state.logic.interaction.InteractionResult;
+import com.fumbbl.ffb.client.state.logic.bb2025.WizardLogicModule;
+import com.fumbbl.ffb.model.Player;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Kalimar
+ */
+@RulesCollection(RulesCollection.Rules.BB2025)
+public class ClientStateWizard extends ClientStateAwt<WizardLogicModule> {
+
+	public ClientStateWizard(FantasyFootballClientAwt pClient) {
+		super(pClient, new WizardLogicModule(pClient));
+	}
+
+	public void setUp() {
+		super.setUp();
+		setClickable(true);
+	}
+
+	@Override
+	public boolean mouseOverField(FieldCoordinate pCoordinate) {
+		InteractionResult result = logicModule.fieldPeek(pCoordinate);
+		switch (result.getKind()) {
+			case RESET:
+				return super.mouseOverField(pCoordinate);
+			case PERFORM:
+				drawSpellmarker(result.getCoordinate(), result.getSpecialEffect());
+				return true;
+			default:
+				break;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean mouseOverPlayer(Player<?> pPlayer) {
+		InteractionResult result = logicModule.playerPeek(pPlayer);
+		switch (result.getKind()) {
+			case RESET:
+				return super.mouseOverPlayer(pPlayer);
+			case PERFORM:
+				drawSpellmarker(result.getCoordinate(), result.getSpecialEffect());
+				return true;
+			default:
+				break;
+		}
+		return false;
+	}
+
+	private void drawSpellmarker(FieldCoordinate pCoordinate, SpecialEffect wizardSpell) {
+		FieldComponent fieldComponent = getClient().getUserInterface().getFieldComponent();
+		switch (wizardSpell) {
+			case LIGHTNING:
+				fieldComponent.getLayerOverPlayers().clearSpellMarker();
+				fieldComponent.getLayerOverPlayers().drawSpellMarker(pCoordinate, IIconProperty.GAME_LIGHTNING_SMALL,
+					!logicModule.isValidLightningTarget(pCoordinate));
+				break;
+			case ZAP:
+				fieldComponent.getLayerOverPlayers().clearSpellMarker();
+				fieldComponent.getLayerOverPlayers().drawSpellMarker(pCoordinate, IIconProperty.GAME_ZAP_SMALL,
+					!logicModule.isValidZapTarget(pCoordinate));
+				break;
+			case FIREBALL:
+				fieldComponent.getLayerOverPlayers().clearFireballMarker();
+				fieldComponent.getLayerOverPlayers().drawFireballMarker(pCoordinate, !logicModule.isValidFireballTarget(pCoordinate));
+				break;
+		}
+		fieldComponent.refresh();
+	}
+
+	@Override
+	public void clickOnField(FieldCoordinate pCoordinate) {
+		InteractionResult result = logicModule.fieldInteraction(pCoordinate);
+		switch (result.getKind()) {
+			case RESET:
+				clearMarker();
+				redisplaySpellDialog();
+				break;
+			case HANDLED:
+				clearMarker();
+				break;
+			default:
+				break;
+		}
+	}
+
+	private void clearMarker() {
+		FieldComponent fieldComponent = getClient().getUserInterface().getFieldComponent();
+		if (getClient().getClientData().getWizardSpell() == SpecialEffect.FIREBALL) {
+			fieldComponent.getLayerOverPlayers().clearFireballMarker();
+		} else {
+			fieldComponent.getLayerOverPlayers().clearSpellMarker();
+		}
+		fieldComponent.refresh();
+	}
+
+	@Override
+	public void clickOnPlayer(Player<?> pPlayer) {
+		InteractionResult result = logicModule.playerInteraction(pPlayer);
+		switch (result.getKind()) {
+			case RESET:
+				clearMarker();
+				redisplaySpellDialog();
+				break;
+			case HANDLED:
+				clearMarker();
+				break;
+			default:
+				break;
+		}
+	}
+
+	private void redisplaySpellDialog() {
+		getClient().getClientData().setWizardSpell(null);
+		getClient().getUserInterface().getDialogManager().setShownDialogParameter(null);
+		getClient().getUserInterface().getDialogManager().updateDialog();
+	}
+
+
+	@Override
+	protected Map<Integer, ClientAction> actionMapping(int menuIndex) {
+		return Collections.emptyMap();
+	}
+}

--- a/ffb-client/src/main/java/com/fumbbl/ffb/client/state/mixed/ClientStateWizard.java
+++ b/ffb-client/src/main/java/com/fumbbl/ffb/client/state/mixed/ClientStateWizard.java
@@ -1,4 +1,4 @@
-package com.fumbbl.ffb.client.state.common;
+package com.fumbbl.ffb.client.state.mixed;
 
 import com.fumbbl.ffb.FieldCoordinate;
 import com.fumbbl.ffb.IIconProperty;
@@ -8,8 +8,8 @@ import com.fumbbl.ffb.client.FantasyFootballClientAwt;
 import com.fumbbl.ffb.client.FieldComponent;
 import com.fumbbl.ffb.client.state.ClientStateAwt;
 import com.fumbbl.ffb.client.state.logic.ClientAction;
-import com.fumbbl.ffb.client.state.logic.WizardLogicModule;
 import com.fumbbl.ffb.client.state.logic.interaction.InteractionResult;
+import com.fumbbl.ffb.client.state.logic.mixed.WizardLogicModule;
 import com.fumbbl.ffb.model.Player;
 
 import java.util.Collections;
@@ -18,7 +18,8 @@ import java.util.Map;
 /**
  * @author Kalimar
  */
-@RulesCollection(RulesCollection.Rules.COMMON)
+@RulesCollection(RulesCollection.Rules.BB2016)
+@RulesCollection(RulesCollection.Rules.BB2020)
 public class ClientStateWizard extends ClientStateAwt<WizardLogicModule> {
 
 	public ClientStateWizard(FantasyFootballClientAwt pClient) {

--- a/ffb-common/src/main/java/com/fumbbl/ffb/factory/bb2025/ArmorModifiers.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/factory/bb2025/ArmorModifiers.java
@@ -44,7 +44,6 @@ public class ArmorModifiers implements com.fumbbl.ffb.factory.ArmorModifiers {
 			}
 		});
 		add(new SpecialEffectArmourModifier("Fireball", 1, false, SpecialEffect.FIREBALL));
-		add(new SpecialEffectArmourModifier("Lightning", 1, false, SpecialEffect.LIGHTNING));
 	}};
 
 	@Override

--- a/ffb-common/src/main/java/com/fumbbl/ffb/factory/bb2025/InjuryModifiers.java
+++ b/ffb-common/src/main/java/com/fumbbl/ffb/factory/bb2025/InjuryModifiers.java
@@ -14,7 +14,6 @@ public class InjuryModifiers implements com.fumbbl.ffb.factory.InjuryModifiers {
 
 	private final Set<? extends InjuryModifier> injuryModifiers = new HashSet<InjuryModifier>() {{
 		add(new SpecialEffectInjuryModifier("Fireball", 1, false, SpecialEffect.FIREBALL));
-		add(new SpecialEffectInjuryModifier("Lightning", 1, false, SpecialEffect.LIGHTNING));
 	}};
 
 	@Override

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2020/StepWizard.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2020/StepWizard.java
@@ -1,4 +1,4 @@
-package com.fumbbl.ffb.server.step.mixed;
+package com.fumbbl.ffb.server.step.bb2020;
 
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
@@ -52,7 +52,6 @@ import java.util.List;
  * @author Kalimar
  */
 @RulesCollection(RulesCollection.Rules.BB2020)
-@RulesCollection(RulesCollection.Rules.BB2025)
 public final class StepWizard extends AbstractStep {
 
 	private SpecialEffect fWizardSpell;

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepWizard.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepWizard.java
@@ -151,10 +151,6 @@ public final class StepWizard extends AbstractStep {
 					getResult().setAnimation(new Animation(AnimationType.SPELL_ZAP, fTargetCoordinate));
 					affectedPlayers.add(game.getFieldModel().getPlayer(fTargetCoordinate));
 				}
-				if (fWizardSpell == SpecialEffect.LIGHTNING) {
-					getResult().setAnimation(new Animation(AnimationType.SPELL_LIGHTNING, fTargetCoordinate));
-					addToAffectedPlayers(affectedPlayers, game.getFieldModel().getPlayer(fTargetCoordinate));
-				}
 				if (fWizardSpell == SpecialEffect.FIREBALL) {
 					getResult().setAnimation(new Animation(AnimationType.SPELL_FIREBALL, fTargetCoordinate));
 					FieldCoordinate[] targetCoordinates = game.getFieldModel().findAdjacentCoordinates(fTargetCoordinate,

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepWizard.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/StepWizard.java
@@ -1,0 +1,224 @@
+package com.fumbbl.ffb.server.step.bb2025;
+
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+import com.fumbbl.ffb.BloodSpot;
+import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
+import com.fumbbl.ffb.FieldCoordinateBounds;
+import com.fumbbl.ffb.PlayerState;
+import com.fumbbl.ffb.RulesCollection;
+import com.fumbbl.ffb.SpecialEffect;
+import com.fumbbl.ffb.TurnMode;
+import com.fumbbl.ffb.dialog.DialogWizardSpellParameter;
+import com.fumbbl.ffb.factory.IFactorySource;
+import com.fumbbl.ffb.inducement.Usage;
+import com.fumbbl.ffb.json.UtilJson;
+import com.fumbbl.ffb.model.Animation;
+import com.fumbbl.ffb.model.AnimationType;
+import com.fumbbl.ffb.model.Game;
+import com.fumbbl.ffb.model.InducementSet;
+import com.fumbbl.ffb.model.Player;
+import com.fumbbl.ffb.model.Team;
+import com.fumbbl.ffb.net.commands.ClientCommandWizardSpell;
+import com.fumbbl.ffb.report.ReportWizardUse;
+import com.fumbbl.ffb.server.GameState;
+import com.fumbbl.ffb.server.IServerJsonOption;
+import com.fumbbl.ffb.server.factory.SequenceGeneratorFactory;
+import com.fumbbl.ffb.server.net.ReceivedCommand;
+import com.fumbbl.ffb.server.step.AbstractStep;
+import com.fumbbl.ffb.server.step.StepAction;
+import com.fumbbl.ffb.server.step.StepCommandStatus;
+import com.fumbbl.ffb.server.step.StepId;
+import com.fumbbl.ffb.server.step.StepParameter;
+import com.fumbbl.ffb.server.step.StepParameterKey;
+import com.fumbbl.ffb.server.step.StepParameterSet;
+import com.fumbbl.ffb.server.step.generator.SequenceGenerator;
+import com.fumbbl.ffb.server.step.generator.SpecialEffect.SequenceParams;
+import com.fumbbl.ffb.server.util.UtilServerDialog;
+import com.fumbbl.ffb.server.util.UtilServerGame;
+import com.fumbbl.ffb.server.util.UtilServerInducementUse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Step in inducement sequence to handle wizard.
+ * <p>
+ * Needs to be initialized with stepParameter HOME_TEAM.
+ * <p>
+ * May push SpellEffect sequences onto the stack.
+ *
+ * @author Kalimar
+ */
+@RulesCollection(RulesCollection.Rules.BB2025)
+public final class StepWizard extends AbstractStep {
+
+	private SpecialEffect fWizardSpell;
+	private FieldCoordinate fTargetCoordinate;
+	private boolean fEndInducement;
+	private TurnMode fOldTurnMode;
+	private boolean fHomeTeam;
+
+	public StepWizard(GameState pGameState) {
+		super(pGameState);
+	}
+
+	public StepId getId() {
+		return StepId.WIZARD;
+	}
+
+	@Override
+	public void init(StepParameterSet pParameterSet) {
+		if (pParameterSet != null) {
+			for (StepParameter parameter : pParameterSet.values()) {
+				// mandatory
+				if (parameter.getKey() == StepParameterKey.HOME_TEAM) {
+					fHomeTeam = (parameter.getValue() != null) ? (Boolean) parameter.getValue() : false;
+				}
+			}
+		}
+	}
+
+	@Override
+	public boolean setParameter(StepParameter parameter) {
+
+		if (parameter != null && parameter.getKey() == StepParameterKey.HOME_TEAM) {
+			fHomeTeam = (parameter.getValue() != null) && (boolean) parameter.getValue();
+			return true;
+		}
+
+		return super.setParameter(parameter);
+	}
+
+	@Override
+	public void start() {
+		super.start();
+		executeStep();
+	}
+
+	@Override
+	public StepCommandStatus handleCommand(ReceivedCommand pReceivedCommand) {
+		StepCommandStatus commandStatus = super.handleCommand(pReceivedCommand);
+		if (commandStatus == StepCommandStatus.UNHANDLED_COMMAND) {
+			switch (pReceivedCommand.getId()) {
+				case CLIENT_WIZARD_SPELL:
+					ClientCommandWizardSpell wizardSpellCommand = (ClientCommandWizardSpell) pReceivedCommand.getCommand();
+					if (wizardSpellCommand.getWizardSpell() == null) { // cancel spellcasting
+						fEndInducement = true;
+					} else {
+						fWizardSpell = wizardSpellCommand.getWizardSpell();
+						if (fHomeTeam) {
+							fTargetCoordinate = wizardSpellCommand.getTargetCoordinate();
+						} else {
+							fTargetCoordinate = wizardSpellCommand.getTargetCoordinate().transform();
+						}
+					}
+					commandStatus = StepCommandStatus.EXECUTE_STEP;
+					break;
+				default:
+					break;
+			}
+		}
+		if (commandStatus == StepCommandStatus.EXECUTE_STEP) {
+			executeStep();
+		}
+		return commandStatus;
+	}
+
+	private void executeStep() {
+		Game game = getGameState().getGame();
+		UtilServerDialog.hideDialog(getGameState());
+		if (fEndInducement) {
+			// cancel spellcasting, no spell effect sequences added to the stack
+			if (fOldTurnMode != null) {
+				game.setTurnMode(fOldTurnMode);
+			}
+			getResult().setNextAction(StepAction.NEXT_STEP);
+		} else if ((fWizardSpell != null) && (fTargetCoordinate != null) && (game.getTurnMode() == TurnMode.WIZARD)) {
+
+			Team team = fHomeTeam ? game.getTeamHome() : game.getTeamAway();
+			getResult().addReport(new ReportWizardUse(team.getId(), fWizardSpell));
+			InducementSet inducementSet = fHomeTeam ? game.getTurnDataHome().getInducementSet() : game.getTurnDataAway().getInducementSet();
+
+			inducementSet.getInducementMapping().keySet().stream()
+				.filter(inducementType -> inducementType.hasUsage(Usage.SPELL)
+					&& inducementType.effects().contains(fWizardSpell)).findFirst().ifPresent(type -> {
+
+				UtilServerInducementUse.useInducement(getGameState(), team, type, 1);
+				List<Player<?>> affectedPlayers = new ArrayList<>();
+				if (fWizardSpell == SpecialEffect.ZAP) {
+					getResult().setAnimation(new Animation(AnimationType.SPELL_ZAP, fTargetCoordinate));
+					affectedPlayers.add(game.getFieldModel().getPlayer(fTargetCoordinate));
+				}
+				if (fWizardSpell == SpecialEffect.LIGHTNING) {
+					getResult().setAnimation(new Animation(AnimationType.SPELL_LIGHTNING, fTargetCoordinate));
+					addToAffectedPlayers(affectedPlayers, game.getFieldModel().getPlayer(fTargetCoordinate));
+				}
+				if (fWizardSpell == SpecialEffect.FIREBALL) {
+					getResult().setAnimation(new Animation(AnimationType.SPELL_FIREBALL, fTargetCoordinate));
+					FieldCoordinate[] targetCoordinates = game.getFieldModel().findAdjacentCoordinates(fTargetCoordinate,
+						FieldCoordinateBounds.FIELD, 1, true);
+					for (int i = targetCoordinates.length - 1; i >= 0; i--) {
+						addToAffectedPlayers(affectedPlayers, game.getFieldModel().getPlayer(targetCoordinates[i]));
+					}
+				}
+				if (fOldTurnMode != null) {
+					game.setTurnMode(fOldTurnMode);
+				}
+				UtilServerGame.syncGameModel(this);
+				PlayerState bloodSpotInjury = new PlayerState(
+					(fWizardSpell == SpecialEffect.FIREBALL) ? PlayerState.HIT_BY_FIREBALL : PlayerState.HIT_BY_LIGHTNING);
+				game.getFieldModel().add(new BloodSpot(fTargetCoordinate, bloodSpotInjury));
+				SequenceGeneratorFactory factory = game.getFactory(FactoryType.Factory.SEQUENCE_GENERATOR);
+				com.fumbbl.ffb.server.step.generator.SpecialEffect generator =
+					(com.fumbbl.ffb.server.step.generator.SpecialEffect) factory.forName(SequenceGenerator.Type.SpecialEffect.name());
+				affectedPlayers.stream().map(affectedPlayer -> new SequenceParams(getGameState(), fWizardSpell, affectedPlayer.getId(),
+					true)).forEach(generator::pushSequence);
+			});
+			getResult().setNextAction(StepAction.NEXT_STEP);
+		} else {
+			if (game.getTurnMode() != (TurnMode.WIZARD)) {
+				fOldTurnMode = game.getTurnMode();
+			}
+			game.setTurnMode(TurnMode.WIZARD);
+
+			UtilServerDialog.showDialog(getGameState(), new DialogWizardSpellParameter((fHomeTeam ? game.getTeamHome() : game.getTeamAway()).getId()), false);
+		}
+	}
+
+	private void addToAffectedPlayers(List<Player<?>> pAffectedPlayers, Player<?> pPlayer) {
+		Game game = getGameState().getGame();
+		PlayerState playerState = game.getFieldModel().getPlayerState(pPlayer);
+		if ((pPlayer != null) && (playerState != null)) {
+			pAffectedPlayers.add(pPlayer);
+		}
+	}
+
+	// JSON serialization
+
+	@Override
+	public JsonObject toJsonValue() {
+		JsonObject jsonObject = super.toJsonValue();
+		IServerJsonOption.WIZARD_SPELL.addTo(jsonObject, fWizardSpell);
+		IServerJsonOption.TARGET_COORDINATE.addTo(jsonObject, fTargetCoordinate);
+		IServerJsonOption.END_INDUCEMENT.addTo(jsonObject, fEndInducement);
+		IServerJsonOption.OLD_TURN_MODE.addTo(jsonObject, fOldTurnMode);
+		IServerJsonOption.HOME_TEAM.addTo(jsonObject, fHomeTeam);
+		return jsonObject;
+	}
+
+	@Override
+	public StepWizard initFrom(IFactorySource source, JsonValue jsonValue) {
+		super.initFrom(source, jsonValue);
+		JsonObject jsonObject = UtilJson.toJsonObject(jsonValue);
+		fWizardSpell = (SpecialEffect) IServerJsonOption.WIZARD_SPELL.getFrom(source, jsonObject);
+		fTargetCoordinate = IServerJsonOption.TARGET_COORDINATE.getFrom(source, jsonObject);
+		fEndInducement = IServerJsonOption.END_INDUCEMENT.getFrom(source, jsonObject);
+		fOldTurnMode = (TurnMode) IServerJsonOption.OLD_TURN_MODE.getFrom(source, jsonObject);
+		Boolean homeTeam = IServerJsonOption.HOME_TEAM.getFrom(source, jsonObject);
+		fHomeTeam = (homeTeam != null) ? homeTeam : false;
+		return this;
+	}
+
+}


### PR DESCRIPTION
Fixed 2 bug reports: 
[Bug 4628](https://fumbbl.com/p/bugs?id/4628)
[Bug 4629](https://fumbbl.com/p/bugs?id/4629)

- Allow BB2025 Fireball and Zap to target own-team players
- Allow BB2025 Fireball to affect prone and stunned players
- Remove Lightning as a BB2025 wizard spell path
