### PR TITLE
Fixed krump and smash from triggering on opponent blocking

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -17,6 +17,7 @@ public class ChangeList {
 			.addBugfix("Joining a running game could leave a second ball icon on the pitch")
 			.addImprovement("Player choice dialogs now grow with the number of listed players (up to 90% of the client height) instead of always showing at most 5 rows")
 			.addBugfix("Tentacles: Being held did not end the player action, allowing the held player to still pass, hand off, foul or block")
+			.addBugfix("Krump and Smash: Was offered when Varag was blocked and the opposing player knocked themselves down")
 		);
 
 		versions.add(new VersionChangeList("3.3.2")

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/KrumpAndSmashModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/KrumpAndSmashModification.java
@@ -1,25 +1,11 @@
 package com.fumbbl.ffb.server.injury.modification.bb2025;
 
 import com.fumbbl.ffb.injury.Block;
-import com.fumbbl.ffb.model.ActingPlayer;
-import com.fumbbl.ffb.model.Game;
-import com.fumbbl.ffb.server.injury.modification.ModificationParams;
-
 import java.util.Collections;
 
 public class KrumpAndSmashModification extends RerollArmourModification {
 	public KrumpAndSmashModification() {
 		super(Collections.singleton(Block.class));
 	}
-
-	@Override
-	protected boolean tryArmourRollModification(ModificationParams params) {
-		Game game = params.getGameState().getGame();
-		ActingPlayer actingPlayer = game.getActingPlayer();
-
-		return actingPlayer != null
-			&& actingPlayer.getPlayerId().equals(params.getNewContext().fAttackerId)
-			&& super.tryArmourRollModification(params);
-	}
+	
 }
-

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/KrumpAndSmashModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/KrumpAndSmashModification.java
@@ -7,5 +7,4 @@ public class KrumpAndSmashModification extends RerollArmourModification {
 	public KrumpAndSmashModification() {
 		super(Collections.singleton(Block.class));
 	}
-	
 }

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/KrumpAndSmashModification.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/injury/modification/bb2025/KrumpAndSmashModification.java
@@ -1,10 +1,25 @@
 package com.fumbbl.ffb.server.injury.modification.bb2025;
 
 import com.fumbbl.ffb.injury.Block;
+import com.fumbbl.ffb.model.ActingPlayer;
+import com.fumbbl.ffb.model.Game;
+import com.fumbbl.ffb.server.injury.modification.ModificationParams;
+
 import java.util.Collections;
 
 public class KrumpAndSmashModification extends RerollArmourModification {
 	public KrumpAndSmashModification() {
 		super(Collections.singleton(Block.class));
 	}
+
+	@Override
+	protected boolean tryArmourRollModification(ModificationParams params) {
+		Game game = params.getGameState().getGame();
+		ActingPlayer actingPlayer = game.getActingPlayer();
+
+		return actingPlayer != null
+			&& actingPlayer.getPlayerId().equals(params.getNewContext().fAttackerId)
+			&& super.tryArmourRollModification(params);
+	}
 }
+

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepHandleDropPlayerContext.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepHandleDropPlayerContext.java
@@ -132,7 +132,9 @@ public class StepHandleDropPlayerContext extends AbstractStepWithReRoll {
 				skill = injuryContext.getUsedSkill();
 
 				if (skill.getSkillBehaviour().getInjuryContextModification().appliesToDefender()) {
-					playerId = game.getPlayerById(injuryContext.fDefenderId).getId();
+					playerId = injuryContext.fDefenderId;
+				} else if (StringTool.isProvided(injuryContext.fAttackerId)) {
+					playerId = injuryContext.fAttackerId;
 				} else {
 					playerId = game.getActingPlayer().getPlayerId();
 				}


### PR DESCRIPTION
Fix `Krump and Smash` being offered when Varag is blocked and the opposing player knocks themselves down.

Added an `ActingPlayer` check so now the skill now only applies when the current acting player is the one who caused the Block armour roll.