### PR TITLE
StepBuyInducements: fix NPE on the predefined-inducements path | Enables Inducements as part of the use_predefined_inducements step

### DIFF
--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/start/StepBuyInducements.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/start/StepBuyInducements.java
@@ -207,6 +207,12 @@ public final class StepBuyInducements extends AbstractStep {
 		if (!UtilGameOption.isOptionEnabled(game, GameOptionId.INDUCEMENTS)) {
 			phase = Phase.DONE;
 		} else if (UtilGameOption.isOptionEnabled(game, GameOptionId.USE_PREDEFINED_INDUCEMENTS)) {
+			// Default the gold fields: a team without an inducement set never enters its block below,
+			// and leaveStep() unboxes these unconditionally.
+			usedInducementGoldHome = 0;
+			availableInducementGoldHome = 0;
+			usedInducementGoldAway = 0;
+			availableInducementGoldAway = 0;
 			Optional<InducementType> starType =
 				((InducementTypeFactory) game.getFactory(FactoryType.Factory.INDUCEMENT_TYPE)).allTypes().stream()
 					.filter(type -> type.hasUsage(Usage.STAR)).findFirst();
@@ -218,7 +224,9 @@ public final class StepBuyInducements extends AbstractStep {
 						.addInducement(new Inducement(starType.get(), starPlayerPositionIds.length));
 					addStarPlayers(game.getTeamHome(), starPlayerPositionIds);
 				}
-				usedInducementGoldHome = availableInducementGoldHome;
+				// availableInducementGoldHome was never assigned on this path; use the predefined set's actual cost so TV and unspent gold stay correct.
+				usedInducementGoldHome = inducementCosts(game.getTeamHome(), game.getTeamHome().getInducementSet());
+				availableInducementGoldHome = usedInducementGoldHome;
 			}
 			if (starType.isPresent() && game.getTeamAway().getInducementSet() != null) {
 				game.getTurnDataAway().getInducementSet().add(game.getTeamAway().getInducementSet());
@@ -228,7 +236,8 @@ public final class StepBuyInducements extends AbstractStep {
 						.addInducement(new Inducement(starType.get(), starPlayerPositionIds.length));
 					addStarPlayers(game.getTeamAway(), starPlayerPositionIds);
 				}
-				usedInducementGoldAway = availableInducementGoldAway;
+				usedInducementGoldAway = inducementCosts(game.getTeamAway(), game.getTeamAway().getInducementSet());
+				availableInducementGoldAway = usedInducementGoldAway;
 			}
 			phase = Phase.DONE;
 


### PR DESCRIPTION
This fix enables teams to carry inducements as part of their XML structure and skip the inducement path. Functionality was present already in the codebase for this behavior but was failing due to a NPE caused by an undefined value in the treasury path. By binding the value to the known gold cash from later in the function, the NPE is resolved and inducements are able to be included as part of a team's XML structure. Competitions will be able to include both inducements and stars as part of their valid ruleset builds and be able to load them at game launch. This fix should work for both pre-existing clients and any future clients if they use the use_predefined_inducements flow to generate team XML's.

-----
With USE_PREDEFINED_INDUCEMENTS enabled, init() never assigned the inducement gold fields, and leaveStep() unboxes them unconditionally:

- A team whose XML carries an <inducementSet> copied the still-null availableInducementGold into usedInducementGold; both are now pinned to the predefined set's actual cost via inducementCosts(), so team value and unspent gold stay correct.
- A team without a set never entered its assignment block at all, leaving both fields null (NPE when only one side has a set). All four fields now default to 0 on entry to the predefined branch.

Adds no behavior change outside the predefined path.