### PR TITLE
Dodge Derivation across planned movement arrays & a fix for Jumping with arrays

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -10,6 +10,7 @@ public class ChangeList {
 
 	public ChangeList() {
 		versions.add(new VersionChangeList("3.4.0")
+			.addBugfix("Movement arrays could skip required dodge rolls, and legacy jump arrays could process intermediate squares as jumps")
 			.addBugfix("B&C: If stunned by a pitch invasion no injury was applied")
 			.addBugfix("Wizard: Fireball did not affect prone or stunned players, and Fireball/Zap could not target own-team players in the 2025 ruleset")
 			.addBugfix(

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2016/move/StepInitMoving.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2016/move/StepInitMoving.java
@@ -139,22 +139,30 @@ public class StepInitMoving extends AbstractStep {
 				case CLIENT_BLITZ_MOVE:
 					ClientCommandBlitzMove blitzMoveCommand = (ClientCommandBlitzMove) pReceivedCommand.getCommand();
 					boolean homePlayerBlitz = UtilServerSteps.checkCommandIsFromHomePlayer(getGameState(), pReceivedCommand);
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)
-							&& UtilServerPlayerMove.isValidMove(getGameState(), blitzMoveCommand, homePlayerBlitz)
-							&& !ArrayTool.isProvided(fMoveStack)) {
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation blitzMoveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), blitzMoveCommand,
+								homePlayerBlitz, fMoveStack);
+						if (!blitzMoveValidation.isAccepted()) {
+							break;
+						}
 						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-								UtilServerPlayerMove.fetchMoveStack(blitzMoveCommand, homePlayerBlitz)));
+								blitzMoveValidation.getMoveStack()));
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}
 					break;
 				case CLIENT_MOVE:
 					ClientCommandMove moveCommand = (ClientCommandMove) pReceivedCommand.getCommand();
 					boolean homePlayer = UtilServerSteps.checkCommandIsFromHomePlayer(getGameState(), pReceivedCommand);
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)
-							&& UtilServerPlayerMove.isValidMove(getGameState(), moveCommand, homePlayer)
-							&& !ArrayTool.isProvided(fMoveStack)) {
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation moveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), moveCommand,
+								homePlayer, fMoveStack);
+						if (!moveValidation.isAccepted()) {
+							break;
+						}
 						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-								UtilServerPlayerMove.fetchMoveStack(moveCommand, homePlayer)));
+								moveValidation.getMoveStack()));
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}
 					break;

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2016/move/StepInitMoving.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2016/move/StepInitMoving.java
@@ -285,7 +285,8 @@ public class StepInitMoving extends AbstractStep {
 					publishParameter(new StepParameter(StepParameterKey.COORDINATE_FROM, coordinateFrom));
 					publishParameter(new StepParameter(StepParameterKey.COORDINATE_TO, coordinateTo));
 					MoveSquare moveSquare = game.getFieldModel().getMoveSquare(coordinateTo);
-					actingPlayer.setDodging((moveSquare != null) && moveSquare.isDodging() && !actingPlayer.isJumping());
+					actingPlayer.setDodging(UtilServerPlayerMove.deriveDodgeRequired(getGameState(), coordinateTo,
+						moveSquare));
 					actingPlayer.setGoingForIt((moveSquare != null) && moveSquare.isGoingForIt());
 					actingPlayer.setHasMoved(true);
 					game.getTurnData().setTurnStarted(true);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2016/move/StepInitSelecting.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2016/move/StepInitSelecting.java
@@ -121,20 +121,28 @@ public final class StepInitSelecting extends AbstractStep {
 					break;
 				case CLIENT_MOVE:
 					ClientCommandMove moveCommand = (ClientCommandMove) pReceivedCommand.getCommand();
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), moveCommand, homeCommand)) {
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation moveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), moveCommand, homeCommand);
+						if (!moveValidation.isAccepted()) {
+							break;
+						}
 						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-							UtilServerPlayerMove.fetchMoveStack(moveCommand, homeCommand)));
+							moveValidation.getMoveStack()));
 						fDispatchPlayerAction = PlayerAction.MOVE;
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}
 					break;
 				case CLIENT_BLITZ_MOVE:
 					ClientCommandBlitzMove blitzMoveCommand = (ClientCommandBlitzMove) pReceivedCommand.getCommand();
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), blitzMoveCommand, homeCommand)) {
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation blitzMoveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), blitzMoveCommand, homeCommand);
+						if (!blitzMoveValidation.isAccepted()) {
+							break;
+						}
 						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-							UtilServerPlayerMove.fetchMoveStack(blitzMoveCommand, homeCommand)));
+							blitzMoveValidation.getMoveStack()));
 						fDispatchPlayerAction = PlayerAction.BLITZ_MOVE;
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2020/move/StepInitMoving.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2020/move/StepInitMoving.java
@@ -337,7 +337,8 @@ public class StepInitMoving extends AbstractStep {
 					publishParameter(new StepParameter(StepParameterKey.COORDINATE_FROM, coordinateFrom));
 					publishParameter(new StepParameter(StepParameterKey.COORDINATE_TO, coordinateTo));
 					MoveSquare moveSquare = game.getFieldModel().getMoveSquare(coordinateTo);
-					actingPlayer.setDodging((moveSquare != null) && moveSquare.isDodging() && !actingPlayer.isJumping());
+					actingPlayer.setDodging(UtilServerPlayerMove.deriveDodgeRequired(getGameState(), coordinateTo,
+						moveSquare));
 					actingPlayer.setGoingForIt((moveSquare != null) && moveSquare.isGoingForIt());
 					actingPlayer.setHasMoved(true);
 					commitTargetSelection();

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2020/move/StepInitMoving.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2020/move/StepInitMoving.java
@@ -146,26 +146,34 @@ public class StepInitMoving extends AbstractStep {
 				case CLIENT_BLITZ_MOVE:
 					ClientCommandBlitzMove blitzMoveCommand = (ClientCommandBlitzMove) pReceivedCommand.getCommand();
 					boolean homePlayerBlitz = UtilServerSteps.checkCommandIsFromHomePlayer(getGameState(), pReceivedCommand);
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), blitzMoveCommand, homePlayerBlitz)) {
-						publishParameter(new StepParameter(StepParameterKey.MOVE_START, UtilServerPlayerMove.fetchFromSquare(blitzMoveCommand, homePlayerBlitz)));
-						if (!ArrayTool.isProvided(fMoveStack)) {
-							publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-								UtilServerPlayerMove.fetchMoveStack(blitzMoveCommand, homePlayerBlitz)));
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation blitzMoveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), blitzMoveCommand,
+								homePlayerBlitz, fMoveStack);
+						if (!blitzMoveValidation.isAccepted()) {
+							break;
 						}
+						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
+							blitzMoveValidation.getCoordinateFrom()));
+						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
+							blitzMoveValidation.getMoveStack()));
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}
 					break;
 				case CLIENT_MOVE:
 					ClientCommandMove moveCommand = (ClientCommandMove) pReceivedCommand.getCommand();
 					boolean homePlayer = UtilServerSteps.checkCommandIsFromHomePlayer(getGameState(), pReceivedCommand);
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), moveCommand, homePlayer)) {
-						publishParameter(new StepParameter(StepParameterKey.MOVE_START, UtilServerPlayerMove.fetchFromSquare(moveCommand, homePlayer)));
-						if (!ArrayTool.isProvided(fMoveStack)) {
-							publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-								UtilServerPlayerMove.fetchMoveStack(moveCommand, homePlayer)));
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation moveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), moveCommand,
+								homePlayer, fMoveStack);
+						if (!moveValidation.isAccepted()) {
+							break;
 						}
+						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
+							moveValidation.getCoordinateFrom()));
+						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
+							moveValidation.getMoveStack()));
 						ballAndChainRrSetting = moveCommand.getBallAndChainRrSetting();
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2020/shared/StepInitSelecting.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2020/shared/StepInitSelecting.java
@@ -176,11 +176,16 @@ public final class StepInitSelecting extends AbstractStep {
 					break;
 				case CLIENT_MOVE:
 					ClientCommandMove moveCommand = (ClientCommandMove) pReceivedCommand.getCommand();
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), moveCommand, homeCommand)) {
-						publishParameter(new StepParameter(StepParameterKey.MOVE_START, UtilServerPlayerMove.fetchFromSquare(moveCommand, homeCommand)));
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation moveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), moveCommand, homeCommand);
+						if (!moveValidation.isAccepted()) {
+							break;
+						}
+						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
+							moveValidation.getCoordinateFrom()));
 						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-							UtilServerPlayerMove.fetchMoveStack(moveCommand, homeCommand)));
+							moveValidation.getMoveStack()));
 						publishParameter(new StepParameter(StepParameterKey.BALL_AND_CHAIN_RE_ROLL_SETTING, moveCommand.getBallAndChainRrSetting()));
 						fDispatchPlayerAction = PlayerAction.MOVE;
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
@@ -188,11 +193,16 @@ public final class StepInitSelecting extends AbstractStep {
 					break;
 				case CLIENT_BLITZ_MOVE:
 					ClientCommandBlitzMove blitzMoveCommand = (ClientCommandBlitzMove) pReceivedCommand.getCommand();
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), blitzMoveCommand, homeCommand)) {
-						publishParameter(new StepParameter(StepParameterKey.MOVE_START, UtilServerPlayerMove.fetchFromSquare(blitzMoveCommand, homeCommand)));
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation blitzMoveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), blitzMoveCommand, homeCommand);
+						if (!blitzMoveValidation.isAccepted()) {
+							break;
+						}
+						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
+							blitzMoveValidation.getCoordinateFrom()));
 						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-							UtilServerPlayerMove.fetchMoveStack(blitzMoveCommand, homeCommand)));
+							blitzMoveValidation.getMoveStack()));
 						fDispatchPlayerAction = PlayerAction.BLITZ_MOVE;
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepInitMoving.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepInitMoving.java
@@ -368,7 +368,8 @@ public class StepInitMoving extends AbstractStep {
 					publishParameter(new StepParameter(StepParameterKey.COORDINATE_FROM, coordinateFrom));
 					publishParameter(new StepParameter(StepParameterKey.COORDINATE_TO, coordinateTo));
 					MoveSquare moveSquare = game.getFieldModel().getMoveSquare(coordinateTo);
-					actingPlayer.setDodging((moveSquare != null) && moveSquare.isDodging() && !actingPlayer.isJumping());
+					actingPlayer.setDodging(UtilServerPlayerMove.deriveDodgeRequired(getGameState(), coordinateTo,
+						moveSquare));
 					actingPlayer.setGoingForIt((moveSquare != null) && moveSquare.isGoingForIt());
 					actingPlayer.setHasMoved(true);
 					commitTargetSelection();

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepInitMoving.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/move/StepInitMoving.java
@@ -151,28 +151,34 @@ public class StepInitMoving extends AbstractStep {
 				case CLIENT_BLITZ_MOVE:
 					ClientCommandBlitzMove blitzMoveCommand = (ClientCommandBlitzMove) pReceivedCommand.getCommand();
 					boolean homePlayerBlitz = UtilServerSteps.checkCommandIsFromHomePlayer(getGameState(), pReceivedCommand);
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), blitzMoveCommand, homePlayerBlitz)) {
-						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
-							UtilServerPlayerMove.fetchFromSquare(blitzMoveCommand, homePlayerBlitz)));
-						if (!ArrayTool.isProvided(fMoveStack)) {
-							publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-								UtilServerPlayerMove.fetchMoveStack(blitzMoveCommand, homePlayerBlitz)));
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation blitzMoveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), blitzMoveCommand,
+								homePlayerBlitz, fMoveStack);
+						if (!blitzMoveValidation.isAccepted()) {
+							break;
 						}
+						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
+							blitzMoveValidation.getCoordinateFrom()));
+						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
+							blitzMoveValidation.getMoveStack()));
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}
 					break;
 				case CLIENT_MOVE:
 					ClientCommandMove moveCommand = (ClientCommandMove) pReceivedCommand.getCommand();
 					boolean homePlayer = UtilServerSteps.checkCommandIsFromHomePlayer(getGameState(), pReceivedCommand);
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), moveCommand, homePlayer)) {
-						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
-							UtilServerPlayerMove.fetchFromSquare(moveCommand, homePlayer)));
-						if (!ArrayTool.isProvided(fMoveStack)) {
-							publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-								UtilServerPlayerMove.fetchMoveStack(moveCommand, homePlayer)));
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation moveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), moveCommand,
+								homePlayer, fMoveStack);
+						if (!moveValidation.isAccepted()) {
+							break;
 						}
+						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
+							moveValidation.getCoordinateFrom()));
+						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
+							moveValidation.getMoveStack()));
 						ballAndChainRrSetting = moveCommand.getBallAndChainRrSetting();
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepInitSelecting.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/step/bb2025/shared/StepInitSelecting.java
@@ -209,11 +209,16 @@ public final class StepInitSelecting extends AbstractStep {
 					break;
 				case CLIENT_MOVE:
 					ClientCommandMove moveCommand = (ClientCommandMove) pReceivedCommand.getCommand();
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), moveCommand, homeCommand)) {
-						publishParameter(new StepParameter(StepParameterKey.MOVE_START, UtilServerPlayerMove.fetchFromSquare(moveCommand, homeCommand)));
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), moveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation moveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), moveCommand, homeCommand);
+						if (!moveValidation.isAccepted()) {
+							break;
+						}
+						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
+							moveValidation.getCoordinateFrom()));
 						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-							UtilServerPlayerMove.fetchMoveStack(moveCommand, homeCommand)));
+							moveValidation.getMoveStack()));
 						publishParameter(new StepParameter(StepParameterKey.BALL_AND_CHAIN_RE_ROLL_SETTING, moveCommand.getBallAndChainRrSetting()));
 						fDispatchPlayerAction = PlayerAction.MOVE;
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
@@ -221,11 +226,16 @@ public final class StepInitSelecting extends AbstractStep {
 					break;
 				case CLIENT_BLITZ_MOVE:
 					ClientCommandBlitzMove blitzMoveCommand = (ClientCommandBlitzMove) pReceivedCommand.getCommand();
-					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)
-						&& UtilServerPlayerMove.isValidMove(getGameState(), blitzMoveCommand, homeCommand)) {
-						publishParameter(new StepParameter(StepParameterKey.MOVE_START, UtilServerPlayerMove.fetchFromSquare(blitzMoveCommand, homeCommand)));
+					if (UtilServerSteps.checkCommandWithActingPlayer(getGameState(), blitzMoveCommand)) {
+						UtilServerPlayerMove.MoveStackValidation blitzMoveValidation =
+							UtilServerPlayerMove.validateAndFetchMoveStack(getGameState(), blitzMoveCommand, homeCommand);
+						if (!blitzMoveValidation.isAccepted()) {
+							break;
+						}
+						publishParameter(new StepParameter(StepParameterKey.MOVE_START,
+							blitzMoveValidation.getCoordinateFrom()));
 						publishParameter(new StepParameter(StepParameterKey.MOVE_STACK,
-							UtilServerPlayerMove.fetchMoveStack(blitzMoveCommand, homeCommand)));
+							blitzMoveValidation.getMoveStack()));
 						fDispatchPlayerAction = PlayerAction.BLITZ_MOVE;
 						commandStatus = StepCommandStatus.EXECUTE_STEP;
 					}

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/util/UtilServerPlayerMove.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/util/UtilServerPlayerMove.java
@@ -152,6 +152,57 @@ public class UtilServerPlayerMove {
 			pHomeCommand ? DebugLog.COMMAND_CLIENT_HOME : DebugLog.COMMAND_CLIENT_AWAY, pMessage);
 	}
 
+	/**
+	 * Returns whether the acting player must dodge when leaving its current square.
+	 * This is the authoritative rule used both when publishing move offers and when
+	 * consuming each coordinate of a retained movement stack.
+	 */
+	public static boolean isDodgeRequired(Game pGame, ActingPlayer pActingPlayer) {
+		return (pGame != null) && (pActingPlayer != null) && (pActingPlayer.getPlayer() != null)
+			&& !pActingPlayer.getPlayer().hasSkillProperty(NamedProperties.ignoreTacklezonesWhenMoving)
+			&& (UtilPlayer.findTacklezones(pGame, pActingPlayer.getPlayer()) > 0);
+	}
+
+	/**
+	 * Derives the dodge flag from the live departure square and records any
+	 * disagreement with the client-facing offer metadata. A jump owns its own
+	 * escape roll and therefore never also dodges.
+	 */
+	public static boolean deriveDodgeRequired(GameState pGameState, FieldCoordinate pCoordinateTo,
+		MoveSquare pOfferedMove) {
+		if ((pGameState == null) || (pGameState.getGame() == null)) {
+			return false;
+		}
+		Game game = pGameState.getGame();
+		ActingPlayer actingPlayer = game.getActingPlayer();
+		boolean jumping = (actingPlayer != null) && actingPlayer.isJumping();
+		boolean derived = (actingPlayer != null) && !jumping
+			&& isDodgeRequired(game, actingPlayer);
+		Boolean offered = (pOfferedMove == null) ? null : pOfferedMove.isDodging();
+		// Jump offers store their jump target in MoveSquare.minimumRollDodge, so
+		// MoveSquare.isDodging() is intentionally not a dodge signal on this path.
+		if (!jumping && ((derived && (offered == null)) || ((offered != null) && (offered != derived)))) {
+			logDodgeDerivationDivergence(pGameState, actingPlayer, pCoordinateTo, offered, derived);
+		}
+		return derived;
+	}
+
+	private static void logDodgeDerivationDivergence(GameState pGameState, ActingPlayer pActingPlayer,
+		FieldCoordinate pCoordinateTo, Boolean pOffered, boolean pDerived) {
+		if ((pGameState.getServer() == null) || (pGameState.getServer().getDebugLog() == null)) {
+			return;
+		}
+		String commandKind = (pActingPlayer == null) || (pActingPlayer.getPlayerAction() == null)
+			? "UNKNOWN" : pActingPlayer.getPlayerAction().name();
+		String playerId = (pActingPlayer == null) ? null : pActingPlayer.getPlayerId();
+		pGameState.getServer().getDebugLog().log(IServerLogLevel.WARN, pGameState.getGame().getId(),
+			"!Dodge derivation divergence command=" + commandKind
+				+ " player=" + playerId
+				+ " square=" + pCoordinateTo
+				+ " offered=" + pOffered
+				+ " derived=" + pDerived);
+	}
+
 	public static final class MoveStackValidation {
 		private final boolean accepted;
 		private final FieldCoordinate coordinateFrom;
@@ -268,8 +319,7 @@ public class UtilServerPlayerMove {
 
 		boolean goForIt;
 		int minimumRollDodge = 0;
-		boolean dodging = !actingPlayer.getPlayer().hasSkillProperty(NamedProperties.ignoreTacklezonesWhenMoving)
-				&& (UtilPlayer.findTacklezones(game, actingPlayer.getPlayer()) > 0);
+		boolean dodging = isDodgeRequired(game, actingPlayer);
 		AgilityMechanic mechanic = (AgilityMechanic) game.getRules().getFactory(Factory.MECHANIC).forName(Mechanic.Type.AGILITY.name());
 		if (jumping) {
 			JumpModifierFactory modifierFactory = game.getFactory(FactoryType.Factory.JUMP_MODIFIER);

--- a/ffb-server/src/main/java/com/fumbbl/ffb/server/util/UtilServerPlayerMove.java
+++ b/ffb-server/src/main/java/com/fumbbl/ffb/server/util/UtilServerPlayerMove.java
@@ -42,37 +42,163 @@ import java.util.Set;
  */
 public class UtilServerPlayerMove {
 
-	public static boolean isValidMove(GameState pGameState, ClientCommandMove pMoveCommand, boolean pHomeCommand) {
-		if ((pMoveCommand == null) || (pMoveCommand.getCoordinateFrom() == null)
-				|| !ArrayTool.isProvided(pMoveCommand.getCoordinatesTo())) {
-			return false;
-		}
-		FieldCoordinate coordinateFrom = pHomeCommand ? pMoveCommand.getCoordinateFrom()
-				: pMoveCommand.getCoordinateFrom().transform();
-		return isValidMove(pGameState, coordinateFrom, pHomeCommand);
+	public static MoveStackValidation validateAndFetchMoveStack(GameState pGameState,
+		ClientCommandMove pMoveCommand, boolean pHomeCommand) {
+		return validateAndFetchMoveStack(pGameState, pMoveCommand, pHomeCommand, null);
 	}
 
-	public static boolean isValidMove(GameState pGameState, ClientCommandBlitzMove pMoveCommand, boolean pHomeCommand) {
-		if ((pMoveCommand == null) || (pMoveCommand.getCoordinateFrom() == null)
-				|| !ArrayTool.isProvided(pMoveCommand.getCoordinatesTo())) {
-			return false;
+	public static MoveStackValidation validateAndFetchMoveStack(GameState pGameState,
+		ClientCommandMove pMoveCommand, boolean pHomeCommand, FieldCoordinate[] pRetainedMoveStack) {
+		if (ArrayTool.isProvided(pRetainedMoveStack)) {
+			return MoveStackValidation.rejected();
 		}
-		FieldCoordinate coordinateFrom = pHomeCommand ? pMoveCommand.getCoordinateFrom()
-				: pMoveCommand.getCoordinateFrom().transform();
-		return isValidMove(pGameState, coordinateFrom, pHomeCommand);
+		if (pMoveCommand == null) {
+			return MoveStackValidation.rejected();
+		}
+		return validateAndFetchMoveStack(pGameState, pMoveCommand.getCoordinateFrom(),
+			pMoveCommand.getCoordinatesTo(), pHomeCommand, pMoveCommand.getId().name());
 	}
 
-	private static boolean isValidMove(GameState pGameState, FieldCoordinate coordinateFrom, boolean pHomeCommand) {
+	public static MoveStackValidation validateAndFetchMoveStack(GameState pGameState,
+		ClientCommandBlitzMove pMoveCommand, boolean pHomeCommand) {
+		return validateAndFetchMoveStack(pGameState, pMoveCommand, pHomeCommand, null);
+	}
+
+	public static MoveStackValidation validateAndFetchMoveStack(GameState pGameState,
+		ClientCommandBlitzMove pMoveCommand, boolean pHomeCommand, FieldCoordinate[] pRetainedMoveStack) {
+		if (ArrayTool.isProvided(pRetainedMoveStack)) {
+			return MoveStackValidation.rejected();
+		}
+		if (pMoveCommand == null) {
+			return MoveStackValidation.rejected();
+		}
+		return validateAndFetchMoveStack(pGameState, pMoveCommand.getCoordinateFrom(),
+			pMoveCommand.getCoordinatesTo(), pHomeCommand, pMoveCommand.getId().name());
+	}
+
+	private static MoveStackValidation validateAndFetchMoveStack(GameState pGameState,
+		FieldCoordinate pCoordinateFrom, FieldCoordinate[] pCoordinatesTo, boolean pHomeCommand,
+		String pCommandName) {
+		if ((pGameState == null) || (pCoordinateFrom == null) || !ArrayTool.isProvided(pCoordinatesTo)) {
+			return MoveStackValidation.rejected();
+		}
+
 		Game game = pGameState.getGame();
+		if ((game == null) || (game.getActingPlayer() == null) || (game.getActingPlayer().getPlayer() == null)) {
+			return MoveStackValidation.rejected();
+		}
+
+		FieldCoordinate coordinateFrom = pHomeCommand ? pCoordinateFrom : pCoordinateFrom.transform();
+		FieldCoordinate[] moveStack = fetchMoveStack(pCoordinatesTo, pHomeCommand);
 		ActingPlayer actingPlayer = game.getActingPlayer();
 		FieldCoordinate playerCoordinate = game.getFieldModel().getPlayerCoordinate(actingPlayer.getPlayer());
-		if ((playerCoordinate != null) && playerCoordinate.equals(coordinateFrom)) {
-			return true;
+		if ((playerCoordinate == null) || !playerCoordinate.equals(coordinateFrom)) {
+			logMoveCommand(pGameState, pHomeCommand, IServerLogLevel.DEBUG,
+				"!Client move out of sync, Command dropped");
+			return MoveStackValidation.rejected();
 		}
-		pGameState.getServer().getDebugLog().log(IServerLogLevel.DEBUG, game.getId(),
-			pHomeCommand ? DebugLog.COMMAND_CLIENT_HOME : DebugLog.COMMAND_CLIENT_AWAY,
-			"!Client move out of sync, Command dropped");
-		return false;
+
+		if (!actingPlayer.isJumping()) {
+			return MoveStackValidation.accepted(coordinateFrom, moveStack, false);
+		}
+
+		FieldCoordinate finalDestination = moveStack[moveStack.length - 1];
+		if ((finalDestination == null) || !FieldCoordinateBounds.FIELD.isInBounds(finalDestination)) {
+			logJumpRejection(pGameState, pHomeCommand, pCommandName, "destination missing or out of bounds");
+			return MoveStackValidation.rejected();
+		}
+
+		MoveSquare offeredMove = game.getFieldModel().getMoveSquare(finalDestination);
+		if (offeredMove == null) {
+			logJumpRejection(pGameState, pHomeCommand, pCommandName, "destination not currently offered");
+			return MoveStackValidation.rejected();
+		}
+
+		JumpMechanic jumpMechanic = (JumpMechanic) game.getFactory(Factory.MECHANIC)
+			.forName(Mechanic.Type.JUMP.name());
+		if ((jumpMechanic == null) || !jumpMechanic.isValidJump(game, actingPlayer.getPlayer(),
+			coordinateFrom, finalDestination)) {
+			logJumpRejection(pGameState, pHomeCommand, pCommandName, "destination invalid for ruleset");
+			return MoveStackValidation.rejected();
+		}
+
+		if (moveStack.length == 1) {
+			return MoveStackValidation.accepted(coordinateFrom, moveStack, false);
+		}
+
+		logMoveCommand(pGameState, pHomeCommand, IServerLogLevel.WARN,
+			"!Legacy jump path normalized command=" + pCommandName
+				+ " player=" + actingPlayer.getPlayerId()
+				+ " count=" + moveStack.length
+				+ " from=" + coordinateFrom
+				+ " final=" + finalDestination);
+		return MoveStackValidation.accepted(coordinateFrom,
+			new FieldCoordinate[] { finalDestination }, true);
+	}
+
+	private static void logJumpRejection(GameState pGameState, boolean pHomeCommand,
+		String pCommandName, String pReason) {
+		logMoveCommand(pGameState, pHomeCommand, IServerLogLevel.DEBUG,
+			"!Jump move dropped command=" + pCommandName + " reason=" + pReason);
+	}
+
+	private static void logMoveCommand(GameState pGameState, boolean pHomeCommand, int pLevel,
+		String pMessage) {
+		if ((pGameState == null) || (pGameState.getGame() == null) || (pGameState.getServer() == null)
+			|| (pGameState.getServer().getDebugLog() == null)) {
+			return;
+		}
+		pGameState.getServer().getDebugLog().log(pLevel, pGameState.getGame().getId(),
+			pHomeCommand ? DebugLog.COMMAND_CLIENT_HOME : DebugLog.COMMAND_CLIENT_AWAY, pMessage);
+	}
+
+	public static final class MoveStackValidation {
+		private final boolean accepted;
+		private final FieldCoordinate coordinateFrom;
+		private final FieldCoordinate[] moveStack;
+		private final boolean normalized;
+
+		private MoveStackValidation(boolean pAccepted, FieldCoordinate pCoordinateFrom,
+			FieldCoordinate[] pMoveStack, boolean pNormalized) {
+			accepted = pAccepted;
+			coordinateFrom = pCoordinateFrom;
+			moveStack = copyOf(pMoveStack);
+			normalized = pNormalized;
+		}
+
+		private static MoveStackValidation accepted(FieldCoordinate pCoordinateFrom,
+			FieldCoordinate[] pMoveStack, boolean pNormalized) {
+			return new MoveStackValidation(true, pCoordinateFrom, pMoveStack, pNormalized);
+		}
+
+		private static MoveStackValidation rejected() {
+			return new MoveStackValidation(false, null, new FieldCoordinate[0], false);
+		}
+
+		public boolean isAccepted() {
+			return accepted;
+		}
+
+		public FieldCoordinate getCoordinateFrom() {
+			return coordinateFrom;
+		}
+
+		public FieldCoordinate[] getMoveStack() {
+			return copyOf(moveStack);
+		}
+
+		public boolean isNormalized() {
+			return normalized;
+		}
+
+		private static FieldCoordinate[] copyOf(FieldCoordinate[] pCoordinates) {
+			if (pCoordinates == null) {
+				return new FieldCoordinate[0];
+			}
+			FieldCoordinate[] result = new FieldCoordinate[pCoordinates.length];
+			System.arraycopy(pCoordinates, 0, result, 0, pCoordinates.length);
+			return result;
+		}
 	}
 
 	public static void updateMoveSquares(GameState pGameState, boolean jumping) {

--- a/ffb-server/src/test/java/com/fumbbl/ffb/server/util/UtilServerPlayerMoveDodgeDerivationTest.java
+++ b/ffb-server/src/test/java/com/fumbbl/ffb/server/util/UtilServerPlayerMoveDodgeDerivationTest.java
@@ -1,0 +1,147 @@
+package com.fumbbl.ffb.server.util;
+
+import com.fumbbl.ffb.FieldCoordinate;
+import com.fumbbl.ffb.MoveSquare;
+import com.fumbbl.ffb.PlayerAction;
+import com.fumbbl.ffb.model.ActingPlayer;
+import com.fumbbl.ffb.model.Game;
+import com.fumbbl.ffb.model.Player;
+import com.fumbbl.ffb.model.property.NamedProperties;
+import com.fumbbl.ffb.server.DebugLog;
+import com.fumbbl.ffb.server.FantasyFootballServer;
+import com.fumbbl.ffb.server.GameState;
+import com.fumbbl.ffb.server.IServerLogLevel;
+import com.fumbbl.ffb.util.UtilPlayer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+class UtilServerPlayerMoveDodgeDerivationTest {
+
+	private static final long GAME_ID = 47L;
+	private static final String PLAYER_ID = "moving-player";
+	private static final FieldCoordinate DESTINATION = new FieldCoordinate(10, 7);
+
+	@Mock
+	private GameState gameState;
+	@Mock
+	private Game game;
+	@Mock
+	private ActingPlayer actingPlayer;
+	@Mock
+	private Player player;
+	@Mock
+	private MoveSquare offeredMove;
+	@Mock
+	private FantasyFootballServer server;
+	@Mock
+	private DebugLog debugLog;
+
+	private MockedStatic<UtilPlayer> utilPlayer;
+
+	@BeforeEach
+	void setUp() {
+		given(gameState.getGame()).willReturn(game);
+		given(gameState.getServer()).willReturn(server);
+		given(server.getDebugLog()).willReturn(debugLog);
+		given(game.getId()).willReturn(GAME_ID);
+		given(game.getActingPlayer()).willReturn(actingPlayer);
+		given(actingPlayer.getPlayer()).willReturn(player);
+		given(actingPlayer.getPlayerId()).willReturn(PLAYER_ID);
+		given(actingPlayer.getPlayerAction()).willReturn(PlayerAction.MOVE);
+		utilPlayer = mockStatic(UtilPlayer.class);
+	}
+
+	@AfterEach
+	void tearDown() {
+		utilPlayer.close();
+	}
+
+	@Test
+	void derivesEachArrayPopFromItsLiveDepartureSquare() {
+		utilPlayer.when(() -> UtilPlayer.findTacklezones(game, player)).thenReturn(1, 1, 0);
+
+		assertTrue(UtilServerPlayerMove.deriveDodgeRequired(gameState, DESTINATION, null));
+		assertTrue(UtilServerPlayerMove.deriveDodgeRequired(gameState, DESTINATION, null));
+		assertFalse(UtilServerPlayerMove.deriveDodgeRequired(gameState, DESTINATION, null));
+
+		verify(debugLog, times(2)).log(IServerLogLevel.WARN, GAME_ID,
+			"!Dodge derivation divergence command=MOVE player=" + PLAYER_ID
+				+ " square=" + DESTINATION + " offered=null derived=true");
+	}
+
+	@Test
+	void matchingFreshOfferRetainsFirstSquareParityWithoutDiagnostic() {
+		utilPlayer.when(() -> UtilPlayer.findTacklezones(game, player)).thenReturn(1);
+		given(offeredMove.isDodging()).willReturn(true);
+
+		assertTrue(UtilServerPlayerMove.deriveDodgeRequired(gameState, DESTINATION, offeredMove));
+
+		verifyNoInteractions(debugLog);
+	}
+
+	@Test
+	void liveMarkedStateOverridesStaleFalseOffer() {
+		utilPlayer.when(() -> UtilPlayer.findTacklezones(game, player)).thenReturn(1);
+		given(offeredMove.isDodging()).willReturn(false);
+
+		assertTrue(UtilServerPlayerMove.deriveDodgeRequired(gameState, DESTINATION, offeredMove));
+
+		verify(debugLog).log(IServerLogLevel.WARN, GAME_ID,
+			"!Dodge derivation divergence command=MOVE player=" + PLAYER_ID
+				+ " square=" + DESTINATION + " offered=false derived=true");
+	}
+
+	@Test
+	void liveUnmarkedStateOverridesStaleTrueOffer() {
+		utilPlayer.when(() -> UtilPlayer.findTacklezones(game, player)).thenReturn(0);
+		given(offeredMove.isDodging()).willReturn(true);
+
+		assertFalse(UtilServerPlayerMove.deriveDodgeRequired(gameState, DESTINATION, offeredMove));
+
+		verify(debugLog).log(IServerLogLevel.WARN, GAME_ID,
+			"!Dodge derivation divergence command=MOVE player=" + PLAYER_ID
+				+ " square=" + DESTINATION + " offered=true derived=false");
+	}
+
+	@Test
+	void missingOfferOnUnmarkedInteriorRemainsNoDodgeWithoutDiagnostic() {
+		utilPlayer.when(() -> UtilPlayer.findTacklezones(game, player)).thenReturn(0);
+
+		assertFalse(UtilServerPlayerMove.deriveDodgeRequired(gameState, DESTINATION, null));
+
+		verifyNoInteractions(debugLog);
+	}
+
+	@Test
+	void tackleZoneIgnoringMoverNeverDodges() {
+		given(player.hasSkillProperty(NamedProperties.ignoreTacklezonesWhenMoving)).willReturn(true);
+		utilPlayer.when(() -> UtilPlayer.findTacklezones(game, player)).thenReturn(2);
+
+		assertFalse(UtilServerPlayerMove.deriveDodgeRequired(gameState, DESTINATION, null));
+		verifyNoInteractions(debugLog);
+	}
+
+	@Test
+	void jumpingPlayerNeverAlsoDodges() {
+		given(actingPlayer.isJumping()).willReturn(true);
+		given(offeredMove.isDodging()).willReturn(true);
+		utilPlayer.when(() -> UtilPlayer.findTacklezones(game, player)).thenReturn(2);
+
+		assertFalse(UtilServerPlayerMove.deriveDodgeRequired(gameState, DESTINATION, offeredMove));
+		verifyNoInteractions(debugLog);
+	}
+}

--- a/ffb-server/src/test/java/com/fumbbl/ffb/server/util/UtilServerPlayerMoveJumpArrayTest.java
+++ b/ffb-server/src/test/java/com/fumbbl/ffb/server/util/UtilServerPlayerMoveJumpArrayTest.java
@@ -1,0 +1,211 @@
+package com.fumbbl.ffb.server.util;
+
+import com.fumbbl.ffb.FactoryType;
+import com.fumbbl.ffb.FieldCoordinate;
+import com.fumbbl.ffb.MoveSquare;
+import com.fumbbl.ffb.factory.MechanicsFactory;
+import com.fumbbl.ffb.mechanics.JumpMechanic;
+import com.fumbbl.ffb.model.ActingPlayer;
+import com.fumbbl.ffb.model.FieldModel;
+import com.fumbbl.ffb.model.Game;
+import com.fumbbl.ffb.model.Player;
+import com.fumbbl.ffb.model.TargetSelectionState;
+import com.fumbbl.ffb.model.TurnData;
+import com.fumbbl.ffb.net.commands.ClientCommandBlitzMove;
+import com.fumbbl.ffb.net.commands.ClientCommandMove;
+import com.fumbbl.ffb.server.GameState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+class UtilServerPlayerMoveJumpArrayTest {
+
+	private static final String PLAYER_ID = "jump-player";
+	private static final FieldCoordinate FROM = new FieldCoordinate(8, 7);
+	private static final FieldCoordinate INTERMEDIATE = new FieldCoordinate(9, 7);
+	private static final FieldCoordinate FINAL = new FieldCoordinate(10, 7);
+
+	@Mock
+	private GameState gameState;
+	@Mock
+	private Game game;
+	@Mock
+	private ActingPlayer actingPlayer;
+	@Mock
+	private Player player;
+	@Mock
+	private FieldModel fieldModel;
+	@Mock
+	private MechanicsFactory mechanicsFactory;
+	@Mock
+	private JumpMechanic jumpMechanic;
+	@Mock
+	private MoveSquare offeredMove;
+	@Mock
+	private TurnData turnData;
+
+	@BeforeEach
+	void setUp() {
+		given(gameState.getGame()).willReturn(game);
+		given(game.getActingPlayer()).willReturn(actingPlayer);
+		given(actingPlayer.getPlayer()).willReturn(player);
+		given(actingPlayer.getPlayerId()).willReturn(PLAYER_ID);
+		given(game.getFieldModel()).willReturn(fieldModel);
+		given(fieldModel.getPlayerCoordinate(player)).willReturn(FROM);
+		given(fieldModel.getMoveSquare(FINAL)).willReturn(offeredMove);
+		given(game.getFactory(FactoryType.Factory.MECHANIC)).willReturn(mechanicsFactory);
+		given(game.getTurnData()).willReturn(turnData);
+		given(mechanicsFactory.forName(anyString())).willReturn(jumpMechanic);
+		given(jumpMechanic.isValidJump(game, player, FROM, FINAL)).willReturn(true);
+		given(actingPlayer.isJumping()).willReturn(true);
+	}
+
+	@Test
+	void normalizesLegacyJumpArrayToItsOfferedDestination() {
+		ClientCommandMove command = move(FROM, INTERMEDIATE, FINAL);
+
+		UtilServerPlayerMove.MoveStackValidation result =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, command, true);
+
+		assertTrue(result.isAccepted());
+		assertTrue(result.isNormalized());
+		assertEquals(FROM, result.getCoordinateFrom());
+		assertArrayEquals(new FieldCoordinate[] { FINAL }, result.getMoveStack());
+	}
+
+	@Test
+	void leavesCurrentSingletonJumpCommandUnchanged() {
+		UtilServerPlayerMove.MoveStackValidation result =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, move(FROM, FINAL), true);
+
+		assertTrue(result.isAccepted());
+		assertFalse(result.isNormalized());
+		assertArrayEquals(new FieldCoordinate[] { FINAL }, result.getMoveStack());
+	}
+
+	@Test
+	void leavesOrdinaryMovementArrayUnchanged() {
+		given(actingPlayer.isJumping()).willReturn(false);
+
+		UtilServerPlayerMove.MoveStackValidation result =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, move(FROM, INTERMEDIATE, FINAL), true);
+
+		assertTrue(result.isAccepted());
+		assertFalse(result.isNormalized());
+		assertArrayEquals(new FieldCoordinate[] { INTERMEDIATE, FINAL }, result.getMoveStack());
+	}
+
+	@Test
+	void rejectsStaleOfferButAllowsRetryWhenTheSameOfferReturns() {
+		ClientCommandMove command = move(FROM, INTERMEDIATE, FINAL);
+		given(fieldModel.getMoveSquare(FINAL)).willReturn(null, offeredMove);
+
+		UtilServerPlayerMove.MoveStackValidation rejected =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, command, true);
+		UtilServerPlayerMove.MoveStackValidation retried =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, command, true);
+
+		assertFalse(rejected.isAccepted());
+		assertArrayEquals(new FieldCoordinate[0], rejected.getMoveStack());
+		assertTrue(retried.isAccepted());
+		assertArrayEquals(new FieldCoordinate[] { FINAL }, retried.getMoveStack());
+	}
+
+	@Test
+	void rejectsDestinationThatTheCurrentRulesetNoLongerAllows() {
+		given(jumpMechanic.isValidJump(game, player, FROM, FINAL)).willReturn(false);
+
+		UtilServerPlayerMove.MoveStackValidation result =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, move(FROM, INTERMEDIATE, FINAL), true);
+
+		assertFalse(result.isAccepted());
+		assertArrayEquals(new FieldCoordinate[0], result.getMoveStack());
+	}
+
+	@Test
+	void transformsAwayCoordinatesExactlyOnceBeforeValidationAndNormalization() {
+		FieldCoordinate clientFrom = FROM.transform();
+		FieldCoordinate clientIntermediate = INTERMEDIATE.transform();
+		FieldCoordinate clientFinal = FINAL.transform();
+
+		UtilServerPlayerMove.MoveStackValidation result =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState,
+				move(clientFrom, clientIntermediate, clientFinal), false);
+
+		assertTrue(result.isAccepted());
+		assertEquals(FROM, result.getCoordinateFrom());
+		assertArrayEquals(new FieldCoordinate[] { FINAL }, result.getMoveStack());
+	}
+
+	@Test
+	void appliesTheSameNormalizationContractToBlitzMove() {
+		ClientCommandBlitzMove command = new ClientCommandBlitzMove(PLAYER_ID, FROM,
+			new FieldCoordinate[] { INTERMEDIATE, FINAL });
+
+		UtilServerPlayerMove.MoveStackValidation result =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, command, true);
+
+		assertTrue(result.isAccepted());
+		assertTrue(result.isNormalized());
+		assertArrayEquals(new FieldCoordinate[] { FINAL }, result.getMoveStack());
+	}
+
+	@Test
+	void rejectedBlitzLeavesTeamActionAndTargetSelectionStateUntouched() {
+		given(fieldModel.getMoveSquare(FINAL)).willReturn(null);
+		ClientCommandBlitzMove command = new ClientCommandBlitzMove(PLAYER_ID, FROM,
+			new FieldCoordinate[] { INTERMEDIATE, FINAL });
+
+		UtilServerPlayerMove.MoveStackValidation result =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, command, true);
+
+		assertFalse(result.isAccepted());
+		verifyNoInteractions(turnData);
+		verify(fieldModel, never()).setTargetSelectionState(any(TargetSelectionState.class));
+	}
+
+	@Test
+	void retainedStackRejectsNewMoveAndBlitzWithoutPublishingAnotherStack() {
+		FieldCoordinate[] retained = new FieldCoordinate[] { INTERMEDIATE };
+
+		UtilServerPlayerMove.MoveStackValidation moveResult =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, move(FROM, FINAL), true, retained);
+		UtilServerPlayerMove.MoveStackValidation blitzResult =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState,
+				new ClientCommandBlitzMove(PLAYER_ID, FROM, new FieldCoordinate[] { FINAL }), true, retained);
+
+		assertFalse(moveResult.isAccepted());
+		assertFalse(blitzResult.isAccepted());
+		assertArrayEquals(new FieldCoordinate[0], moveResult.getMoveStack());
+		assertArrayEquals(new FieldCoordinate[0], blitzResult.getMoveStack());
+	}
+
+	@Test
+	void acceptedResultDoesNotExposeItsInternalStack() {
+		UtilServerPlayerMove.MoveStackValidation result =
+			UtilServerPlayerMove.validateAndFetchMoveStack(gameState, move(FROM, FINAL), true);
+		FieldCoordinate[] firstRead = result.getMoveStack();
+		firstRead[0] = mock(FieldCoordinate.class);
+
+		assertArrayEquals(new FieldCoordinate[] { FINAL }, result.getMoveStack());
+	}
+
+	private ClientCommandMove move(FieldCoordinate from, FieldCoordinate... to) {
+		return new ClientCommandMove(PLAYER_ID, from, to, null);
+	}
+}


### PR DESCRIPTION
This fix touches the movement rail on FUMBBL but offers the benefits of hardening the path through which client supplied movement arrays are ingested by the server.

**Current server behavior**
CLIENT_MOVE and CLIENT_BLITZ_MOVE carry an initial coordinate and an array of requested destination coordinates. For example:
```
CLIENT_MOVE: [B, C, D]
```
The command does not contain per-coordinate dodge or roll metadata.
Before movement begins, the server publishes a collection of MoveSquare offers from the player’s current position, A. MoveSquare(B) therefore describes the move from A to B, including whether leaving A requires a dodge.

The server then consumes the movement array one coordinate at a time:
```
Consume B → retain [C, D]
Consume C → retain [D]
Consume D → retain []
```
Each coordinate's metadata is not normally regenerated while that array is undergoing consumption meaning that the "safety" of the move was determined by the initial square and whether it was determined to be safe. More concretely, if A>B did not require a dodge to move then B>C also will not carry that requirement. But if an event occured that would force this to refresh the metadata-- For example, interacting with a shadowing player, diving tackle, or otherwise-- this issue could resolve mid-flight. Consequently, when the server would later resolve B to C, the offered metadata of "isDodging" can return as null from MoveSquare and will fail to false. This means no dodge required.

The previous dodge gate was effectively:
```
actingPlayer.setDodging(
    moveSquare != null
        && moveSquare.isDodging()
        && !actingPlayer.isJumping()
);
```
This is perfectly fine for movement paths wherein unsafe boundaries (ones which require a dodge roll or skill test) are not being plotted across (the way that the current FUMBBL client does). But it does introduce a potential cheat vector: a bad actor could utilize this behavior to send commands that would permit the user to "gauntlet run" in so far as they passed the first roll or that the first movement did not require a roll. The server would also accept that movement as a perfectly valid and legal action. It also means, as implemented, movement arrays can never be plotted across unsafe surfaces.

In the proposed fix, the need for a dodge is calculated by the server draining the movement array and calculating .isDodgeRequred at each step of the process through a new deriveDodgeRequired helper for each coordinate. Whether a dodge is required is not calculated on the first square but on each individual coordinate change and its relation to the game state. The currently applied movement rules are utilized to do so.

**Three wins:**
1. FFBServer will now determine dodge eligibility at each step of a client supplied movement array. This allows a planner to execute across an entire planned array-- even if the coordinate requires a dodge. Currently, this does not change any behavior on the FFB planner as current behavior does not permit moving across unsafe squares. 
2. This hardens the server against a potential cheat vector. The server will perform the decisioning on whether a move is considered safe and execute rolls in accordance with metadata being populated by each individual coordinate for dodges. Dodge eligibility is determined at the per-square level for the array. Currently, a modified client can submit a movement array, the server would accept it and the player could simply move through a series of tackle zones that would require a dodge so long as either the first move did not require a dodge or that they passed the roll required on the first movement.
3. The Jump fix reduces the jump destination to a single coordinate and ensures it's in compliance with the current ruleset. It's the smaller win of the two and mostly just a formality of a fix but does go back and fix something important.

**Additional notes:**
1. As this touches the primary interaction surface of the client, I would recommend independent verification of the movement array mechanics in a test environment. I will attach the harness tests and documentation here for your review but this is a critical surface and one of the primary ways users experience the game.
2. [jump-array-dodge-server-behavior.md](https://github.com/user-attachments/files/31566770/jump-array-dodge-server-behavior.md) This markdown file contains Codex's own summary of the issue. I've reviewed it and it seems to explain it well. But, obviously, this is from an AI agent so would recommend a review.
4. [upstream-jump-dodge-pr-evidence-1a237df11.zip](https://github.com/user-attachments/files/31567146/upstream-jump-dodge-pr-evidence-1a237df11.zip) This contains all test evidence including harness runs as of Aug 28th
5. As this does not affect the actual client given the current behavior as implemented, there is a case to be made for not including this upgrade. I am personally biased in that it enables improvements in a rendering flow and allows for smoother display of movement in high latency environments but given the potential for failure I'm quite nervous about that.

