### PR TITLE
Fix client freeze during startup caused by off-EDT user interface work

### DIFF
--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ClientReplayer.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ClientReplayer.java
@@ -4,7 +4,6 @@ import com.fumbbl.ffb.ClientMode;
 import com.fumbbl.ffb.CommonProperty;
 import com.fumbbl.ffb.FactoryManager;
 import com.fumbbl.ffb.FactoryType;
-import com.fumbbl.ffb.FantasyFootballException;
 import com.fumbbl.ffb.IClientPropertyValue;
 import com.fumbbl.ffb.PlayerState;
 import com.fumbbl.ffb.PlayerType;
@@ -15,6 +14,7 @@ import com.fumbbl.ffb.client.handler.ClientCommandHandler;
 import com.fumbbl.ffb.client.handler.ClientCommandHandlerMode;
 import com.fumbbl.ffb.client.state.logic.ReplayLogicModule;
 import com.fumbbl.ffb.client.ui.LogComponent;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 import com.fumbbl.ffb.dialog.DialogCoinChoiceParameter;
 import com.fumbbl.ffb.dialog.DialogStartGameParameter;
 import com.fumbbl.ffb.factory.IFactorySource;
@@ -39,7 +39,7 @@ import com.fumbbl.ffb.report.ReportId;
 import com.fumbbl.ffb.util.ArrayTool;
 import com.fumbbl.ffb.util.UtilBox;
 
-import javax.swing.*;
+import javax.swing.Timer;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -66,6 +66,7 @@ public class ClientReplayer implements ActionListener {
 	private boolean fReplayDirectionForward, fStopping, fSkipping, control, online;
 	private ClientCommandHandlerMode lastMode;
 	private final Timer fTimer;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	public ClientReplayer(FantasyFootballClient pClient) {
 		fClient = pClient;
@@ -510,11 +511,7 @@ public class ClientReplayer implements ActionListener {
 	public void positionOnFirstCommand() {
 		LogComponent log = getClient().getUserInterface().getLog();
 		replayToCommand(log.findCommandNr(1));
-		try {
-			SwingUtilities.invokeAndWait(() -> getClient().getUserInterface().getLog().getLogScrollPane().setScrollBarToMinimum());
-		} catch (Exception pE) {
-			throw new FantasyFootballException(pE);
-		}
+		uiDispatcher.runOnUiThread(() -> getClient().getUserInterface().getLog().getLogScrollPane().setScrollBarToMinimum());
 	}
 
 	public void positionOnLastCommand() {
@@ -524,15 +521,7 @@ public class ClientReplayer implements ActionListener {
 		if (serverCommand != null) {
 			highlightCommand(serverCommand.getCommandNr());
 		}
-		try {
-			if (!SwingUtilities.isEventDispatchThread()) {
-				SwingUtilities.invokeAndWait(() -> getClient().getUserInterface().getLog().getLogScrollPane().setScrollBarToMaximum());
-			} else {
-				getClient().getUserInterface().getLog().getLogScrollPane().setScrollBarToMaximum();
-			}
-		} catch (Exception pE) {
-			throw new FantasyFootballException(pE);
-		}
+		uiDispatcher.runOnUiThread(() -> getClient().getUserInterface().getLog().getLogScrollPane().setScrollBarToMaximum());
 	}
 
 	public void stop() {
@@ -605,8 +594,9 @@ public class ClientReplayer implements ActionListener {
 		}
 	}
 
-	public synchronized void handleCommand(ServerCommandReplayStatus command, ReplayLogicModule.ReplayCallbacks callbacks) {
-		SwingUtilities.invokeLater(() -> {
+	// must not be synchronized, the body is handed over to the event dispatch thread which also needs this monitor
+	public void handleCommand(ServerCommandReplayStatus command, ReplayLogicModule.ReplayCallbacks callbacks) {
+		uiDispatcher.runLaterOnUiThread(() -> {
 			fTimer.stop();
 			setReplaySpeed(command.getSpeed());
 			if (fLastReplayPosition != command.getCommandNr()) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/IconCache.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/IconCache.java
@@ -353,11 +353,10 @@ public class IconCache {
 					});
 
 				} catch (Exception pAny) {
-					synchronized (this) {
-						getClient().logError(0, pAny.getMessage());
-						// This should catch issues where the image is broken...
-						getClient().getUserInterface().getStatusReport().reportIconLoadFailure(iconUrl);
-					}
+					// no lock may be held here, reporting hands work over to the event dispatch thread
+					getClient().logError(0, pAny.getMessage());
+					// This should catch issues where the image is broken...
+					getClient().getUserInterface().getStatusReport().reportIconLoadFailure(iconUrl);
 				}
 
 			}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/UserInterface.java
@@ -2,7 +2,6 @@ package com.fumbbl.ffb.client;
 
 import com.fumbbl.ffb.ClientMode;
 import com.fumbbl.ffb.CommonProperty;
-import com.fumbbl.ffb.FantasyFootballException;
 import com.fumbbl.ffb.client.dialog.DialogHandler;
 import com.fumbbl.ffb.client.dialog.DialogInformation;
 import com.fumbbl.ffb.client.dialog.DialogLeaveGame;
@@ -19,6 +18,7 @@ import com.fumbbl.ffb.client.ui.LogComponent;
 import com.fumbbl.ffb.client.ui.ScoreBarComponent;
 import com.fumbbl.ffb.client.ui.SideBarComponent;
 import com.fumbbl.ffb.client.util.MarkerService;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 import com.fumbbl.ffb.client.util.rng.MouseEntropySource;
 import com.fumbbl.ffb.dialog.DialogId;
 import com.fumbbl.ffb.model.Game;
@@ -31,7 +31,6 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
-import java.lang.reflect.InvocationTargetException;
 
 /**
  * @author Kalimar
@@ -66,6 +65,7 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 	private final CoordinateConverter coordinateConverter;
 	private final ClientSketchManager sketchManager;
 	private final MarkerService markerService;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 
 	public UserInterface(FantasyFootballClient pClient) {
@@ -328,7 +328,11 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 		getGameMenuBar().refresh();
 	}
 
-	public synchronized void init(GameOptions gameOptions) {
+	public void init(GameOptions gameOptions) {
+		uiDispatcher.runOnUiThread(() -> initOnUiThread(gameOptions));
+	}
+
+	private void initOnUiThread(GameOptions gameOptions) {
 
 		if (gameOptions != null && ArrayTool.isProvided(gameOptions.getOptions())) {
 			getStatusReport().init(gameOptions);
@@ -379,19 +383,11 @@ public class UserInterface extends JFrame implements WindowListener, IDialogClos
 	}
 
 	public void invokeAndWait(Runnable pRunnable) {
-		try {
-			if (SwingUtilities.isEventDispatchThread()) {
-				pRunnable.run();
-			} else {
-				SwingUtilities.invokeAndWait(pRunnable);
-			}
-		} catch (InterruptedException | InvocationTargetException e) {
-			throw new FantasyFootballException(e);
-		}
+		uiDispatcher.runOnUiThread(pRunnable);
 	}
 
 	public void invokeLater(Runnable pRunnable) {
-		SwingUtilities.invokeLater(pRunnable);
+		uiDispatcher.runLaterOnUiThread(pRunnable);
 	}
 
 	public MouseEntropySource getMouseEntropySource() {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/Dialog.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/Dialog.java
@@ -10,6 +10,7 @@ import com.fumbbl.ffb.client.UserInterface;
 import com.fumbbl.ffb.client.ui.menu.GameMenuBar;
 import com.fumbbl.ffb.client.ui.swing.JComboBox;
 import com.fumbbl.ffb.client.ui.swing.JLabel;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 import com.fumbbl.ffb.util.StringTool;
 
 import javax.swing.BorderFactory;
@@ -40,6 +41,7 @@ public abstract class Dialog extends JInternalFrame implements IDialog, MouseLis
 	private DialogKeyGuard keyGuard;
 
 	private final JPanel contentPanel;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	public Dialog(FantasyFootballClient pClient, String pTitle, boolean pCloseable) {
 		super(pTitle, false, pCloseable);
@@ -64,27 +66,31 @@ public abstract class Dialog extends JInternalFrame implements IDialog, MouseLis
 
 	public void showDialog(IDialogCloseListener pCloseListener) {
 		fCloseListener = pCloseListener;
-		UserInterface userInterface = getClient().getUserInterface();
-		fChatInputFocus = userInterface.getChat().hasChatInputFocus();
-		userInterface.getDesktop().add(Dialog.this);
-		installKeyGuard();
-		setVisible(true);
-		moveToFront();
-		if (fChatInputFocus) {
-			userInterface.getChat().requestChatInputFocus();
-		}
-	}
-
-	public void hideDialog() {
-		removeKeyGuard();
-		if (isVisible()) {
-			setVisible(false);
+		uiDispatcher.runOnUiThread(() -> {
 			UserInterface userInterface = getClient().getUserInterface();
-			userInterface.getDesktop().remove(this);
+			fChatInputFocus = userInterface.getChat().hasChatInputFocus();
+			userInterface.getDesktop().add(Dialog.this);
+			installKeyGuard();
+			setVisible(true);
+			moveToFront();
 			if (fChatInputFocus) {
 				userInterface.getChat().requestChatInputFocus();
 			}
-		}
+		});
+	}
+
+	public void hideDialog() {
+		uiDispatcher.runOnUiThread(() -> {
+			removeKeyGuard();
+			if (isVisible()) {
+				setVisible(false);
+				UserInterface userInterface = getClient().getUserInterface();
+				userInterface.getDesktop().remove(this);
+				if (fChatInputFocus) {
+					userInterface.getChat().requestChatInputFocus();
+				}
+			}
+		});
 	}
 
 	private void installKeyGuard() {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogAboutHandler.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogAboutHandler.java
@@ -3,18 +3,19 @@ package com.fumbbl.ffb.client.dialog;
 import com.fumbbl.ffb.client.FantasyFootballClient;
 
 import javax.swing.JPanel;
+import javax.swing.Timer;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Timer;
-import java.util.TimerTask;
 
 /**
  * 
  * @author Kalimar
  */
 public class DialogAboutHandler extends DialogHandler {
+
+	private static final int CLOSE_DELAY_IN_MILLIS = 5000;
 
 	private Timer fCloseTimer;
 
@@ -64,18 +65,20 @@ public class DialogAboutHandler extends DialogHandler {
 		getClient().getUserInterface().setGlassPane(new MyGlassPane());
 		getClient().getUserInterface().getGlassPane().setVisible(true);
 		getClient().getUserInterface().getGlassPane().requestFocus();
-		fCloseTimer = new Timer();
-		fCloseTimer.schedule(new TimerTask() {
-			@Override
-			public void run() {
-				fCloseTimer = null;
-				dialogClosed(getDialog());
-			}
-		}, 5 * 1000);
-		getClient().startClient();
+		// a swing timer fires on the event dispatch thread, so hiding the dialog does not race the user interface
+		fCloseTimer = new Timer(CLOSE_DELAY_IN_MILLIS, event -> {
+			fCloseTimer = null;
+			dialogClosed(getDialog());
+		});
+		fCloseTimer.setRepeats(false);
+		fCloseTimer.start();
 	}
 
 	public void dialogClosed(IDialog pDialog) {
+		if (fCloseTimer != null) {
+			fCloseTimer.stop();
+			fCloseTimer = null;
+		}
 		if (getDialog().isVisible()) {
 			hideDialog();
 			getClient().getUserInterface().getGlassPane().setVisible(false);

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogProgressBar.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/dialog/DialogProgressBar.java
@@ -4,6 +4,7 @@ import com.fumbbl.ffb.client.FantasyFootballClient;
 import com.fumbbl.ffb.client.ui.swing.JButton;
 import com.fumbbl.ffb.client.ui.swing.JLabel;
 import com.fumbbl.ffb.client.ui.swing.JProgressBar;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 import com.fumbbl.ffb.dialog.DialogId;
 import com.fumbbl.ffb.util.StringTool;
 
@@ -11,10 +12,10 @@ import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Kalimar
@@ -23,6 +24,12 @@ public class DialogProgressBar extends Dialog implements ActionListener {
 
 	private final JLabel fMessageLabel;
 	private final JProgressBar fProgressBar;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
+	// progress updates are coalesced, background threads must never wait for the event dispatch thread here
+	private final AtomicReference<Progress> pendingProgress = new AtomicReference<>();
+	private final AtomicBoolean updateScheduled = new AtomicBoolean();
+	private volatile int minimum;
+	private volatile int maximum;
 
 	public DialogProgressBar(FantasyFootballClient pClient, String pTitle) {
 		this(pClient, pTitle, 0, 0);
@@ -35,6 +42,8 @@ public class DialogProgressBar extends Dialog implements ActionListener {
 		JButton fButton = new JButton(dimensionProvider(), "Cancel");
 		fButton.addActionListener(this);
 
+		minimum = pMinValue;
+		maximum = pMaxValue;
 		fProgressBar = new JProgressBar(dimensionProvider(), pMinValue, pMaxValue);
 		fProgressBar.setValue(pMinValue);
 		fProgressBar.setStringPainted(true);
@@ -77,57 +86,57 @@ public class DialogProgressBar extends Dialog implements ActionListener {
 	}
 
 	public int getMinimum() {
-		return fProgressBar.getMinimum();
+		return minimum;
 	}
 
 	public void setMinimum(final int pMinimum) {
-		if (pMinimum != getMinimum()) {
-			if (SwingUtilities.isEventDispatchThread()) {
-				fProgressBar.setMinimum(pMinimum);
-			} else {
-				try {
-					SwingUtilities.invokeAndWait(() -> fProgressBar.setMinimum(pMinimum));
-				} catch (InterruptedException | InvocationTargetException ignored) {
-				}
-			}
+		if (pMinimum != minimum) {
+			minimum = pMinimum;
+			uiDispatcher.runLaterOnUiThread(() -> fProgressBar.setMinimum(pMinimum));
 		}
 	}
 
 	public int getMaximum() {
-		return fProgressBar.getMaximum();
+		return maximum;
 	}
 
 	public void setMaximum(final int pMaximum) {
-		if (pMaximum != getMaximum()) {
-			if (SwingUtilities.isEventDispatchThread()) {
-				fProgressBar.setMaximum(pMaximum);
-			} else {
-				try {
-					SwingUtilities.invokeAndWait(() -> fProgressBar.setMaximum(pMaximum));
-				} catch (InterruptedException | InvocationTargetException ignored) {
-				}
-			}
+		if (pMaximum != maximum) {
+			maximum = pMaximum;
+			uiDispatcher.runLaterOnUiThread(() -> fProgressBar.setMaximum(pMaximum));
 		}
 	}
 
 	public void updateProgress(final int pProgress, final String pMessage) {
-		if (SwingUtilities.isEventDispatchThread()) {
-			fProgressBar.setValue(pProgress);
-			if (StringTool.isProvided(pMessage)) {
-				fMessageLabel.setText(pMessage);
+		pendingProgress.set(new Progress(pProgress, pMessage));
+		if (updateScheduled.compareAndSet(false, true)) {
+			uiDispatcher.runLaterOnUiThread(this::applyPendingProgress);
+		}
+	}
+
+	private void applyPendingProgress() {
+		updateScheduled.set(false);
+		Progress progress = pendingProgress.getAndSet(null);
+		if (progress == null) {
+			return;
+		}
+		fProgressBar.setValue(progress.value);
+		if (StringTool.isProvided(progress.message)) {
+			fMessageLabel.setText(progress.message);
+			// relayouting for every single step stalls the event dispatch thread, only do it when the text grows
+			if (fMessageLabel.getPreferredSize().width > fMessageLabel.getWidth()) {
 				pack();
 			}
-		} else {
-			try {
-				SwingUtilities.invokeAndWait(() -> {
-					fProgressBar.setValue(pProgress);
-					if (StringTool.isProvided(pMessage)) {
-						fMessageLabel.setText(pMessage);
-						pack();
-					}
-				});
-			} catch (InterruptedException | InvocationTargetException ignored) {
-			}
+		}
+	}
+
+	private static class Progress {
+		private final int value;
+		private final String message;
+
+		private Progress(int value, String message) {
+			this.value = value;
+			this.message = message;
 		}
 	}
 

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/handler/ClientCommandHandlerFactory.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/handler/ClientCommandHandlerFactory.java
@@ -17,7 +17,11 @@ public class ClientCommandHandlerFactory {
 
 	private final FantasyFootballClient fClient;
 
+	private static final long ANIMATION_TIMEOUT_IN_MILLIS = 30000;
+
 	private final Map<NetCommandId, ClientCommandHandler> fCommandHandlerById;
+
+	private boolean animationRunning;
 
 	public ClientCommandHandlerFactory(FantasyFootballClient pClient) {
 		fClient = pClient;
@@ -51,17 +55,20 @@ public class ClientCommandHandlerFactory {
 		if (pNetCommand != null) {
 			ClientCommandHandler commandHandler = getCommandHandler(pNetCommand.getId());
 			if (commandHandler != null) {
+				boolean playing = (pMode == ClientCommandHandlerMode.PLAYING);
+				if (playing) {
+					// arm the guard before the handler starts, otherwise a fast animation may signal completion
+					// before this thread starts waiting
+					synchronized (this) {
+						animationRunning = true;
+					}
+				}
 				boolean completed = commandHandler.handleNetCommand(pNetCommand, pMode);
 				if (completed) {
 					updateClientState(pNetCommand, false);
 				} else {
-					if (pMode == ClientCommandHandlerMode.PLAYING) {
-						synchronized (this) {
-							try {
-								wait();
-							} catch (InterruptedException ignored) {
-							}
-						}
+					if (playing) {
+						awaitAnimation();
 					}
 				}
 			} else {
@@ -70,6 +77,30 @@ public class ClientCommandHandlerFactory {
 		} else {
 			fClient.logDebug(gameId, "Received null command");
 
+		}
+	}
+
+	/**
+	 * Waits until the running animation signals completion. Uses a guard and a timeout, so a notification that is
+	 * missed because the event dispatch thread was busy cannot block command processing forever.
+	 */
+	private void awaitAnimation() {
+		synchronized (this) {
+			long deadline = System.currentTimeMillis() + ANIMATION_TIMEOUT_IN_MILLIS;
+			while (animationRunning) {
+				long remaining = deadline - System.currentTimeMillis();
+				if (remaining <= 0) {
+					fClient.logDebug(0, "Timed out waiting for animation to finish");
+					animationRunning = false;
+					break;
+				}
+				try {
+					wait(remaining);
+				} catch (InterruptedException interrupted) {
+					Thread.currentThread().interrupt();
+					animationRunning = false;
+				}
+			}
 		}
 	}
 
@@ -84,6 +115,7 @@ public class ClientCommandHandlerFactory {
 		}
 		if (pNotify) {
 			synchronized (this) {
+				animationRunning = false;
 				notifyAll();
 			}
 		}

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/handler/ClientCommandHandlerGameState.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/handler/ClientCommandHandlerGameState.java
@@ -8,6 +8,7 @@ import com.fumbbl.ffb.client.PlayerIconFactory;
 import com.fumbbl.ffb.client.UserInterface;
 import com.fumbbl.ffb.client.dialog.IDialog;
 import com.fumbbl.ffb.client.dialog.IDialogCloseListener;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 import com.fumbbl.ffb.client.util.UtilClientThrowTeamMate;
 import com.fumbbl.ffb.model.Game;
 import com.fumbbl.ffb.model.Player;
@@ -19,8 +20,6 @@ import com.fumbbl.ffb.net.commands.ServerCommandGameState;
 import com.fumbbl.ffb.option.GameOptionId;
 import com.fumbbl.ffb.util.StringTool;
 
-import javax.swing.SwingUtilities;
-import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashSet;
@@ -37,6 +36,7 @@ import java.util.stream.Collectors;
 public class ClientCommandHandlerGameState extends ClientCommandHandler implements IDialogCloseListener {
 
 	private final SubHandlerGameStateMarking subHandler;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	protected ClientCommandHandlerGameState(FantasyFootballClient pClient) {
 		super(pClient);
@@ -134,19 +134,15 @@ public class ClientCommandHandlerGameState extends ClientCommandHandler implemen
 		UtilClientThrowTeamMate.updateThrownPlayer(getClient());
 
 		if (pMode == ClientCommandHandlerMode.PLAYING) {
-			try {
-				SwingUtilities.invokeAndWait(() -> {
-					UserInterface userInterface = getClient().getUserInterface();
-					userInterface.init(game.getOptions());
-					getClient().updateClientState();
-					userInterface.getDialogManager().updateDialog();
-					userInterface.getGameMenuBar().updateMissingPlayers();
-					userInterface.getGameMenuBar().updateInducements();
-					userInterface.getChat().requestChatInputFocus();
-				});
-			} catch (InterruptedException | InvocationTargetException e) {
-				getClient().logWithOutGameId(e);
-			}
+			uiDispatcher.runOnUiThread(() -> {
+				UserInterface userInterface = getClient().getUserInterface();
+				userInterface.init(game.getOptions());
+				getClient().updateClientState();
+				userInterface.getDialogManager().updateDialog();
+				userInterface.getGameMenuBar().updateMissingPlayers();
+				userInterface.getGameMenuBar().updateInducements();
+				userInterface.getChat().requestChatInputFocus();
+			});
 		}
 
 		getClient().initRulesDependentMembers();

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/handler/ClientCommandHandlerGameState.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/handler/ClientCommandHandlerGameState.java
@@ -1,5 +1,6 @@
 package com.fumbbl.ffb.client.handler;
 
+import com.fumbbl.ffb.FantasyFootballException;
 import com.fumbbl.ffb.IIconProperty;
 import com.fumbbl.ffb.Weather;
 import com.fumbbl.ffb.client.FantasyFootballClient;
@@ -134,15 +135,19 @@ public class ClientCommandHandlerGameState extends ClientCommandHandler implemen
 		UtilClientThrowTeamMate.updateThrownPlayer(getClient());
 
 		if (pMode == ClientCommandHandlerMode.PLAYING) {
-			uiDispatcher.runOnUiThread(() -> {
-				UserInterface userInterface = getClient().getUserInterface();
-				userInterface.init(game.getOptions());
-				getClient().updateClientState();
-				userInterface.getDialogManager().updateDialog();
-				userInterface.getGameMenuBar().updateMissingPlayers();
-				userInterface.getGameMenuBar().updateInducements();
-				userInterface.getChat().requestChatInputFocus();
-			});
+			try {
+				uiDispatcher.runOnUiThread(() -> {
+					UserInterface userInterface = getClient().getUserInterface();
+					userInterface.init(game.getOptions());
+					getClient().updateClientState();
+					userInterface.getDialogManager().updateDialog();
+					userInterface.getGameMenuBar().updateMissingPlayers();
+					userInterface.getGameMenuBar().updateInducements();
+					userInterface.getChat().requestChatInputFocus();
+				});
+			} catch (FantasyFootballException e) {
+				getClient().logWithOutGameId(e);
+			}
 		}
 
 		getClient().initRulesDependentMembers();

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/model/ChangeList.java
@@ -30,6 +30,8 @@ public class ChangeList {
 			.addBugfix("Swarming: A double clicked end turn button during setup could skip the swarming setup")
 			.addBugfix("Chainsaw: Attacker down (skull or both down) when blocking a player with chainsaw did add chainsaw modifier to armour roll on attacker")
 			.addBugfix("If the only available action was forgo activation, a foul action was started instead")
+			.addBugfix("Client could freeze during startup, for example when the window was moved while a replay was loading")
+			.addImprovement("Replays load noticeably faster, progress dialogs no longer slow down loading")
 		);
 
 		versions.add(new VersionChangeList("3.3.2")

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/ClientState.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/ClientState.java
@@ -142,12 +142,11 @@ public abstract class ClientState<T extends LogicModule, C extends FantasyFootba
 	// must not be synchronized, the progress dialog hands its work over to the event dispatch thread and holding a
 	// lock while doing so deadlocks the client when the event dispatch thread is busy
 	public void updateIconProgress(AtomicInteger count, int total) {
-		DialogProgressBar progressBar = dialogProgress;
-		if (progressBar == null) {
+		if (dialogProgress == null) {
 			return;
 		}
 		int loaded = count.incrementAndGet();
-		progressBar.updateProgress(loaded, String.format("Loaded icon %d of %d.", loaded, total));
+		dialogProgress.updateProgress(loaded, String.format("Loaded icon %d of %d.", loaded, total));
 	}
 
 	public void hideIconProgress() {
@@ -158,4 +157,3 @@ public abstract class ClientState<T extends LogicModule, C extends FantasyFootba
 		}
 	}
 }
-

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/ClientState.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/state/ClientState.java
@@ -7,6 +7,7 @@ import com.fumbbl.ffb.client.FantasyFootballClient;
 import com.fumbbl.ffb.client.dialog.DialogProgressBar;
 import com.fumbbl.ffb.client.dialog.IDialogCloseListener;
 import com.fumbbl.ffb.client.state.logic.LogicModule;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 import com.fumbbl.ffb.net.NetCommand;
 
 import java.awt.event.MouseEvent;
@@ -18,7 +19,8 @@ public abstract class ClientState<T extends LogicModule, C extends FantasyFootba
 	protected final T logicModule;
 
 	protected FieldCoordinate fSelectSquareCoordinate;
-	private DialogProgressBar dialogProgress;
+	private volatile DialogProgressBar dialogProgress;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	public ClientState(C pClient, T logicModule) {
 		fClient = pClient;
@@ -131,18 +133,29 @@ public abstract class ClientState<T extends LogicModule, C extends FantasyFootba
 	}
 
 	public void showIconProgress(IDialogCloseListener listener, int total) {
-		dialogProgress = new DialogProgressBar(getClient(), "Loading icons", 0, total);
-		dialogProgress.showDialog(listener);
+		uiDispatcher.runOnUiThread(() -> {
+			dialogProgress = new DialogProgressBar(getClient(), "Loading icons", 0, total);
+			dialogProgress.showDialog(listener);
+		});
 	}
 
-	public synchronized void updateIconProgress(AtomicInteger count, int total) {
-		String message = String.format("Loaded icon %d of %d.", count.incrementAndGet(), total);
-		dialogProgress.updateProgress(count.get(), message);
+	// must not be synchronized, the progress dialog hands its work over to the event dispatch thread and holding a
+	// lock while doing so deadlocks the client when the event dispatch thread is busy
+	public void updateIconProgress(AtomicInteger count, int total) {
+		DialogProgressBar progressBar = dialogProgress;
+		if (progressBar == null) {
+			return;
+		}
+		int loaded = count.incrementAndGet();
+		progressBar.updateProgress(loaded, String.format("Loaded icon %d of %d.", loaded, total));
 	}
 
 	public void hideIconProgress() {
-		dialogProgress.hideDialog();
+		DialogProgressBar progressBar = dialogProgress;
 		dialogProgress = null;
+		if (progressBar != null) {
+			progressBar.hideDialog();
+		}
 	}
 }
 

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatComponent.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatComponent.java
@@ -7,6 +7,7 @@ import com.fumbbl.ffb.client.ui.chat.ChatSegment;
 import com.fumbbl.ffb.client.ui.chat.MessageParser;
 import com.fumbbl.ffb.client.ui.swing.JTextField;
 import com.fumbbl.ffb.client.ui.swing.WrappingEditorKit;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 import com.fumbbl.ffb.util.StringTool;
 
 import javax.swing.BorderFactory;
@@ -39,6 +40,7 @@ public class ChatComponent extends JPanel implements MouseMotionListener {
 	private final JTextField fChatInputField;
 	private final ReplayControl fReplayControl;
 	private boolean fReplayShown;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	private final List<String> fInputLog;
 	private int fInputLogPosition;
@@ -199,14 +201,16 @@ public class ChatComponent extends JPanel implements MouseMotionListener {
 	}
 
 	public void showReplay(boolean pShowReplay) {
-		removeAll();
-		if (pShowReplay) {
-			add(fReplayControl, BorderLayout.NORTH);
-		}
-		add(fChatScrollPane, BorderLayout.CENTER);
-		add(fChatInputPanel, BorderLayout.SOUTH);
-		revalidate();
-		repaint();
+		uiDispatcher.runOnUiThread(() -> {
+			removeAll();
+			if (pShowReplay) {
+				add(fReplayControl, BorderLayout.NORTH);
+			}
+			add(fChatScrollPane, BorderLayout.CENTER);
+			add(fChatInputPanel, BorderLayout.SOUTH);
+			revalidate();
+			repaint();
+		});
 		fReplayShown = pShowReplay;
 	}
 

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatLogTextPane.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatLogTextPane.java
@@ -6,14 +6,13 @@ import com.fumbbl.ffb.client.ParagraphStyle;
 import com.fumbbl.ffb.client.StyleProvider;
 import com.fumbbl.ffb.client.TextStyle;
 import com.fumbbl.ffb.client.ui.chat.ChatSegment;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 
 import javax.swing.JTextPane;
-import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultCaret;
 
 import java.awt.event.MouseEvent;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 /**
@@ -25,6 +24,7 @@ public class ChatLogTextPane extends JTextPane {
 	private IReplayMouseListener fReplayMouseListener;
 	private final StyleProvider styleProvider;
 	private final DimensionProvider dimensionProvider;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	public ChatLogTextPane(StyleProvider styleProvider, DimensionProvider dimensionProvider) {
 		this.styleProvider = styleProvider;
@@ -68,49 +68,39 @@ public class ChatLogTextPane extends JTextPane {
 
 	public void append(ParagraphStyle pTextIndent, TextStyle pStyle, String pText) {
 
-		try {
-			Runnable runnable;
-			if (pText != null) {
+		TextStyle style = (pStyle != null) ? pStyle : TextStyle.NONE;
+		ParagraphStyle textIndent = (pTextIndent != null) ? pTextIndent : ParagraphStyle.INDENT_0;
 
-				if (pStyle == null) {
-					pStyle = TextStyle.NONE;
+		Runnable runnable = () -> {
+			try {
+				if (pText != null) {
+					fChatLogDocument.setParagraphAttributes(fChatLogDocument.getLength(), 1,
+						fChatLogDocument.getStyle(textIndent.getName()), false);
+					fChatLogDocument.insertString(fChatLogDocument.getLength(), pText,
+						fChatLogDocument.getStyle(style.getName()));
+				} else {
+					fChatLogDocument.insertString(fChatLogDocument.getLength(), ChatLogDocument.LINE_SEPARATOR,
+						fChatLogDocument.getStyle(TextStyle.NONE.getName()));
 				}
-				if (pTextIndent == null) {
-					pTextIndent = ParagraphStyle.INDENT_0;
-				}
-
-				fChatLogDocument.setParagraphAttributes(fChatLogDocument.getLength(), 1,
-					fChatLogDocument.getStyle(pTextIndent.getName()), false);
-				String name = pStyle.getName();
-
-				runnable = () -> {
-					try {
-						fChatLogDocument.insertString(fChatLogDocument.getLength(), pText, fChatLogDocument.getStyle(name));
-					} catch (BadLocationException ex) {
-						throw new FantasyFootballException(ex);
-					}
-				};
-			} else {
-				runnable = () -> {
-					try {
-						fChatLogDocument.insertString(fChatLogDocument.getLength(), ChatLogDocument.LINE_SEPARATOR,
-							fChatLogDocument.getStyle(TextStyle.NONE.getName()));
-					} catch (BadLocationException ex) {
-						throw new FantasyFootballException(ex);
-					}
-				};
+			} catch (BadLocationException ex) {
+				throw new FantasyFootballException(ex);
 			}
+		};
 
-			if (SwingUtilities.isEventDispatchThread()) {
+		if (isDocumentDetached()) {
+			// the document is not shown by any component, so it can be filled without involving the event dispatch
+			// thread, this avoids tens of thousands of round trips while a replay is initialized
+			synchronized (fChatLogDocument) {
 				runnable.run();
-			} else {
-				SwingUtilities.invokeAndWait(runnable);
 			}
-
-		} catch (InterruptedException | InvocationTargetException e) {
-			throw new FantasyFootballException(e);
+		} else {
+			uiDispatcher.runOnUiThread(runnable);
 		}
 
+	}
+
+	private boolean isDocumentDetached() {
+		return getDocument() != fChatLogDocument;
 	}
 
 	public void update() {
@@ -124,44 +114,35 @@ public class ChatLogTextPane extends JTextPane {
 	 * small append calls (e.g. 150+ segments in stress test).
 	 */
 	public void appendBatch(List<ChatSegment> segments, ParagraphStyle paragraphStyle) {
-		try {
-			Runnable runnable = () -> {
-				try {
+		Runnable runnable = () -> {
+			try {
 
-					int startOffset = fChatLogDocument.getParagraphElement(fChatLogDocument.getLength()).getStartOffset();
+				int startOffset = fChatLogDocument.getParagraphElement(fChatLogDocument.getLength()).getStartOffset();
 
-					for (ChatSegment segment : segments) {
-						if (segment.icon != null) {
-							setCaretPosition(fChatLogDocument.getLength());
-							insertIcon(new OffsetIcon(segment.icon.getImage(), segment.offset));
-						} else if (segment.text != null) {
-							TextStyle style = (segment.style == null ? TextStyle.NONE : segment.style);
-							fChatLogDocument.insertString(fChatLogDocument.getLength(), segment.text,
-								fChatLogDocument.getStyle(style.getName()));
-						} else {
-							fChatLogDocument.insertString(fChatLogDocument.getLength(),	ChatLogDocument.LINE_SEPARATOR,
-								fChatLogDocument.getStyle(TextStyle.NONE.getName()));
-						}
+				for (ChatSegment segment : segments) {
+					if (segment.icon != null) {
+						setCaretPosition(fChatLogDocument.getLength());
+						insertIcon(new OffsetIcon(segment.icon.getImage(), segment.offset));
+					} else if (segment.text != null) {
+						TextStyle style = (segment.style == null ? TextStyle.NONE : segment.style);
+						fChatLogDocument.insertString(fChatLogDocument.getLength(), segment.text,
+							fChatLogDocument.getStyle(style.getName()));
+					} else {
+						fChatLogDocument.insertString(fChatLogDocument.getLength(), ChatLogDocument.LINE_SEPARATOR,
+							fChatLogDocument.getStyle(TextStyle.NONE.getName()));
 					}
-
-					int endOffset = fChatLogDocument.getParagraphElement(startOffset).getEndOffset();
-					fChatLogDocument.setParagraphAttributes(startOffset, endOffset - startOffset,
-						fChatLogDocument.getStyle(paragraphStyle.getName()),false	);
-
-				} catch (BadLocationException ex) {
-					throw new FantasyFootballException(ex);
 				}
-			};
 
-			if (SwingUtilities.isEventDispatchThread()) {
-				runnable.run();
-			} else {
-				SwingUtilities.invokeAndWait(runnable);
+				int endOffset = fChatLogDocument.getParagraphElement(startOffset).getEndOffset();
+				fChatLogDocument.setParagraphAttributes(startOffset, endOffset - startOffset,
+					fChatLogDocument.getStyle(paragraphStyle.getName()), false);
+
+			} catch (BadLocationException ex) {
+				throw new FantasyFootballException(ex);
 			}
+		};
 
-		} catch (InterruptedException | InvocationTargetException e) {
-			throw new FantasyFootballException(e);
-		}
+		uiDispatcher.runOnUiThread(runnable);
 	}
 
 }

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatLogTextPane.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatLogTextPane.java
@@ -111,7 +111,7 @@ public class ChatLogTextPane extends JTextPane {
 
 	/**
 	 * Batch insert of chat segments.
-	 *
+	 * <p>
 	 * Performs all inserts in one EDT run, avoiding overhead from many
 	 * small append calls (e.g. 150+ segments in stress test).
 	 */

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatLogTextPane.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/ChatLogTextPane.java
@@ -24,6 +24,7 @@ public class ChatLogTextPane extends JTextPane {
 	private IReplayMouseListener fReplayMouseListener;
 	private final StyleProvider styleProvider;
 	private final DimensionProvider dimensionProvider;
+	private final Object documentMonitor = new Object();
 	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	public ChatLogTextPane(StyleProvider styleProvider, DimensionProvider dimensionProvider) {
@@ -71,27 +72,13 @@ public class ChatLogTextPane extends JTextPane {
 		TextStyle style = (pStyle != null) ? pStyle : TextStyle.NONE;
 		ParagraphStyle textIndent = (pTextIndent != null) ? pTextIndent : ParagraphStyle.INDENT_0;
 
-		Runnable runnable = () -> {
-			try {
-				if (pText != null) {
-					fChatLogDocument.setParagraphAttributes(fChatLogDocument.getLength(), 1,
-						fChatLogDocument.getStyle(textIndent.getName()), false);
-					fChatLogDocument.insertString(fChatLogDocument.getLength(), pText,
-						fChatLogDocument.getStyle(style.getName()));
-				} else {
-					fChatLogDocument.insertString(fChatLogDocument.getLength(), ChatLogDocument.LINE_SEPARATOR,
-						fChatLogDocument.getStyle(TextStyle.NONE.getName()));
-				}
-			} catch (BadLocationException ex) {
-				throw new FantasyFootballException(ex);
-			}
-		};
+		Runnable runnable = () -> appendToDocument(fChatLogDocument, textIndent, style, pText);
 
 		if (isDocumentDetached()) {
 			// the document is not shown by any component, so it can be filled without involving the event dispatch
 			// thread, this avoids tens of thousands of round trips while a replay is initialized
-			synchronized (fChatLogDocument) {
-				runnable.run();
+			synchronized (documentMonitor) {
+				appendToDocument(fChatLogDocument, textIndent, style, pText);
 			}
 		} else {
 			uiDispatcher.runOnUiThread(runnable);
@@ -101,6 +88,21 @@ public class ChatLogTextPane extends JTextPane {
 
 	private boolean isDocumentDetached() {
 		return getDocument() != fChatLogDocument;
+	}
+
+	private void appendToDocument(ChatLogDocument chatLogDocument, ParagraphStyle textIndent, TextStyle style, String text) {
+		try {
+			if (text != null) {
+				chatLogDocument.setParagraphAttributes(chatLogDocument.getLength(), 1,
+					chatLogDocument.getStyle(textIndent.getName()), false);
+				chatLogDocument.insertString(chatLogDocument.getLength(), text, chatLogDocument.getStyle(style.getName()));
+			} else {
+				chatLogDocument.insertString(chatLogDocument.getLength(), ChatLogDocument.LINE_SEPARATOR,
+					chatLogDocument.getStyle(TextStyle.NONE.getName()));
+			}
+		} catch (BadLocationException ex) {
+			throw new FantasyFootballException(ex);
+		}
 	}
 
 	public void update() {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/LogComponent.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/ui/LogComponent.java
@@ -1,6 +1,7 @@
 package com.fumbbl.ffb.client.ui;
 
 import com.fumbbl.ffb.client.*;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 
 import javax.swing.JPanel;
 import javax.swing.text.BadLocationException;
@@ -26,6 +27,7 @@ public class LogComponent extends JPanel implements MouseMotionListener, IReplay
 	private final StyleProvider styleProvider;
 
 	private final FantasyFootballClient fClient;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	public LogComponent(FantasyFootballClient pClient, StyleProvider styleProvider, DimensionProvider dimensionProvider) {
 		fClient = pClient;
@@ -91,12 +93,14 @@ public class LogComponent extends JPanel implements MouseMotionListener, IReplay
 	}
 
 	public void detachLogDocument() {
-		fLogTextPane.detachDocument();
-		fCommandHighlightAreaByCommandNr.clear();
+		uiDispatcher.runOnUiThread(() -> {
+			fLogTextPane.detachDocument();
+			fCommandHighlightAreaByCommandNr.clear();
+		});
 	}
 
 	public void attachLogDocument() {
-		fLogTextPane.attachDocument();
+		uiDispatcher.runOnUiThread(fLogTextPane::attachDocument);
 	}
 
 	public boolean hasCommandHighlight(int pCommandNr) {

--- a/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/util/UiDispatcher.java
+++ b/ffb-client-logic/src/main/java/com/fumbbl/ffb/client/util/UiDispatcher.java
@@ -1,0 +1,64 @@
+package com.fumbbl.ffb.client.util;
+
+import com.fumbbl.ffb.FantasyFootballException;
+
+import javax.swing.SwingUtilities;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Dispatches work to the AWT event dispatch thread.
+ * <p>
+ * Swing components must only be created and modified on the event dispatch thread. Background threads (the client
+ * communication thread, icon download workers, timers) therefore have to hand their user interface work over to the
+ * event dispatch thread. Never call {@link #runOnUiThread(Runnable)} while holding a lock that the event dispatch
+ * thread may need, otherwise the application deadlocks.
+ */
+public class UiDispatcher {
+
+	/**
+	 * @return true if the calling thread is the event dispatch thread
+	 */
+	public boolean isUiThread() {
+		return SwingUtilities.isEventDispatchThread();
+	}
+
+	/**
+	 * Runs the given task on the event dispatch thread and waits for its completion. Runs the task directly when
+	 * already on the event dispatch thread.
+	 *
+	 * @throws FantasyFootballException if the task throws an exception
+	 */
+	public void runOnUiThread(Runnable task) {
+		if (isUiThread()) {
+			task.run();
+			return;
+		}
+		try {
+			SwingUtilities.invokeAndWait(task);
+		} catch (InterruptedException interrupted) {
+			Thread.currentThread().interrupt();
+		} catch (InvocationTargetException targetException) {
+			throw new FantasyFootballException(targetException);
+		}
+	}
+
+	/**
+	 * Schedules the given task on the event dispatch thread without waiting for its completion. Runs the task
+	 * directly when already on the event dispatch thread.
+	 */
+	public void runLaterOnUiThread(Runnable task) {
+		if (isUiThread()) {
+			task.run();
+		} else {
+			SwingUtilities.invokeLater(task);
+		}
+	}
+
+	/**
+	 * Waits until all user interface tasks scheduled before this call have been processed.
+	 */
+	public void awaitPendingUiTasks() {
+		runOnUiThread(() -> {
+		});
+	}
+}

--- a/ffb-client/src/main/java/com/fumbbl/ffb/client/FantasyFootballClientAwt.java
+++ b/ffb-client/src/main/java/com/fumbbl/ffb/client/FantasyFootballClientAwt.java
@@ -13,9 +13,11 @@ import com.fumbbl.ffb.client.overlay.PathSketchOverlay;
 import com.fumbbl.ffb.client.state.ClientStateAwt;
 import com.fumbbl.ffb.client.state.ClientStateFactoryAwt;
 import com.fumbbl.ffb.client.state.logic.LogicModule;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 import com.fumbbl.ffb.model.Game;
 import com.fumbbl.ffb.util.StringTool;
 
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import java.awt.Insets;
 import java.io.IOException;
@@ -43,6 +45,8 @@ public class FantasyFootballClientAwt extends FantasyFootballClient {
 	private final ClientLogger logger;
 	private Overlay activeOverlay;
 	private final PathSketchOverlay pathSketchOverlay;
+
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	private transient int currentMouseButton;
 
@@ -84,12 +88,25 @@ public class FantasyFootballClientAwt extends FantasyFootballClient {
 	}
 
 	public void showUserInterface() {
-		getUserInterface().getFieldComponent().getLayerField().drawWeather(Weather.INTRO);
-		getUserInterface().getFieldComponent().refresh();
-		getUserInterface().setVisible(true);
+		uiDispatcher.runOnUiThread(() -> {
+			getUserInterface().getFieldComponent().getLayerField().drawWeather(Weather.INTRO);
+			getUserInterface().getFieldComponent().refresh();
+			getUserInterface().setVisible(true);
 
-		DialogAboutHandler aboutDialogHandler = new DialogAboutHandler(this);
-		aboutDialogHandler.showDialog();
+			DialogAboutHandler aboutDialogHandler = new DialogAboutHandler(this);
+			aboutDialogHandler.showDialog();
+		});
+
+		// connecting to the server and loading the game or replay must not happen on the event dispatch thread,
+		// otherwise the user interface freezes during startup
+		Thread startupThread = new Thread(() -> {
+			try {
+				startClient();
+			} catch (Exception all) {
+				logWithOutGameId(all);
+			}
+		}, "FFB-Client-Startup");
+		startupThread.start();
 	}
 
 	public void dialogClosed(IDialog pDialog) {
@@ -152,8 +169,15 @@ public class FantasyFootballClientAwt extends FantasyFootballClient {
 				System.out.println(ClientParameters.USAGE);
 				return;
 			}
-			FantasyFootballClientAwt client = new FantasyFootballClientAwt(parameters);
-			client.showUserInterface();
+			// the whole user interface has to be created on the event dispatch thread
+			SwingUtilities.invokeAndWait(() -> {
+				try {
+					FantasyFootballClientAwt client = new FantasyFootballClientAwt(parameters);
+					client.showUserInterface();
+				} catch (Exception all) {
+					all.printStackTrace(System.err);
+				}
+			});
 		} catch (Exception all) {
 			all.printStackTrace(System.err);
 		}

--- a/ffb-client/src/main/java/com/fumbbl/ffb/client/state/common/ClientStateReplay.java
+++ b/ffb-client/src/main/java/com/fumbbl/ffb/client/state/common/ClientStateReplay.java
@@ -15,6 +15,7 @@ import com.fumbbl.ffb.client.state.ClientStateAwt;
 import com.fumbbl.ffb.client.state.logic.ClientAction;
 import com.fumbbl.ffb.client.state.logic.ReplayLogicModule;
 import com.fumbbl.ffb.client.ui.ChatComponent;
+import com.fumbbl.ffb.client.util.UiDispatcher;
 import com.fumbbl.ffb.net.NetCommand;
 import com.fumbbl.ffb.net.ServerStatus;
 import com.fumbbl.ffb.util.StringTool;
@@ -36,8 +37,9 @@ public class ClientStateReplay extends ClientStateAwt<ReplayLogicModule> impleme
 		REPLACE_CHOICE
 	}
 
-	private DialogProgressBar fDialogProgress;
+	private volatile DialogProgressBar fDialogProgress;
 	private DialogState currentDialog = DialogState.NONE;
+	private final UiDispatcher uiDispatcher = new UiDispatcher();
 
 	public ClientStateReplay(FantasyFootballClientAwt pClient) {
 		super(pClient, new ReplayLogicModule(pClient));
@@ -97,19 +99,41 @@ public class ClientStateReplay extends ClientStateAwt<ReplayLogicModule> impleme
 	}
 
 	private void updateProgress(int pProgress, String pFormat) {
-		String message = String.format(pFormat, pProgress, fDialogProgress.getMaximum());
-		fDialogProgress.updateProgress(pProgress, message);
+		DialogProgressBar progressBar = fDialogProgress;
+		if (progressBar == null) {
+			return;
+		}
+		String message = String.format(pFormat, pProgress, progressBar.getMaximum());
+		progressBar.updateProgress(pProgress, message);
 	}
 
 	public void initProgress(int pMinimum, int pMaximum) {
-		fDialogProgress.setMinimum(pMinimum);
-		fDialogProgress.setMaximum(pMaximum);
+		DialogProgressBar progressBar = fDialogProgress;
+		if (progressBar == null) {
+			return;
+		}
+		progressBar.setMinimum(pMinimum);
+		progressBar.setMaximum(pMaximum);
 	}
 
 	private void showProgressDialog() {
-		fDialogProgress = new DialogProgressBar(getClient(), "Receiving Replay");
-		currentDialog = DialogState.REPLAY_PROGRESS;
-		fDialogProgress.showDialog(this);
+		showProgressDialog("Receiving Replay", DialogState.REPLAY_PROGRESS);
+	}
+
+	private void showProgressDialog(String title, DialogState dialogState) {
+		uiDispatcher.runOnUiThread(() -> {
+			fDialogProgress = new DialogProgressBar(getClient(), title);
+			currentDialog = dialogState;
+			fDialogProgress.showDialog(this);
+		});
+	}
+
+	private void hideProgressDialog() {
+		DialogProgressBar progressBar = fDialogProgress;
+		currentDialog = DialogState.NONE;
+		if (progressBar != null) {
+			progressBar.hideDialog();
+		}
 	}
 
 	public boolean actionKeyPressed(ActionKey pActionKey, int menuIndex) {
@@ -212,31 +236,25 @@ public class ClientStateReplay extends ClientStateAwt<ReplayLogicModule> impleme
 
 		@Override
 		public void loadDone() {
-			if (clientStateReplay.fDialogProgress != null) {
-				clientStateReplay.fDialogProgress.hideDialog();
-			}
-			clientStateReplay.currentDialog = DialogState.NONE;
+			clientStateReplay.hideProgressDialog();
 		}
 
 		@Override
 		public void startReplayerInit() {
-			clientStateReplay.fDialogProgress = new DialogProgressBar(clientStateReplay.getClient(), "Initializing Replay");
-			clientStateReplay.currentDialog = DialogState.INIT_PROGRESS;
-			clientStateReplay.fDialogProgress.showDialog(clientStateReplay);
+			clientStateReplay.showProgressDialog("Initializing Replay", DialogState.INIT_PROGRESS);
 		}
 
 		@Override
 		public void replayerInitialized() {
-			if (clientStateReplay.fDialogProgress != null) {
-				clientStateReplay.fDialogProgress.hideDialog();
-			}
-			clientStateReplay.currentDialog = DialogState.NONE;
+			clientStateReplay.hideProgressDialog();
 		}
 
 		@Override
 		public void promptForReplayChoice() {
-			clientStateReplay.currentDialog = DialogState.REPLACE_CHOICE;
-			new DialogReplayModeChoice(clientStateReplay.getClient()).showDialog(clientStateReplay);
+			clientStateReplay.uiDispatcher.runOnUiThread(() -> {
+				clientStateReplay.currentDialog = DialogState.REPLACE_CHOICE;
+				new DialogReplayModeChoice(clientStateReplay.getClient()).showDialog(clientStateReplay);
+			});
 		}
 
 		@Override

--- a/ffb-client/src/main/java/com/fumbbl/ffb/client/state/common/ClientStateReplay.java
+++ b/ffb-client/src/main/java/com/fumbbl/ffb/client/state/common/ClientStateReplay.java
@@ -99,21 +99,19 @@ public class ClientStateReplay extends ClientStateAwt<ReplayLogicModule> impleme
 	}
 
 	private void updateProgress(int pProgress, String pFormat) {
-		DialogProgressBar progressBar = fDialogProgress;
-		if (progressBar == null) {
+		if (fDialogProgress == null) {
 			return;
 		}
-		String message = String.format(pFormat, pProgress, progressBar.getMaximum());
-		progressBar.updateProgress(pProgress, message);
+		String message = String.format(pFormat, pProgress, fDialogProgress.getMaximum());
+		fDialogProgress.updateProgress(pProgress, message);
 	}
 
 	public void initProgress(int pMinimum, int pMaximum) {
-		DialogProgressBar progressBar = fDialogProgress;
-		if (progressBar == null) {
+		if (fDialogProgress == null) {
 			return;
 		}
-		progressBar.setMinimum(pMinimum);
-		progressBar.setMaximum(pMaximum);
+		fDialogProgress.setMinimum(pMinimum);
+		fDialogProgress.setMaximum(pMaximum);
 	}
 
 	private void showProgressDialog() {


### PR DESCRIPTION
The client built and mutated its Swing user interface from the main thread, the client communication thread and icon download workers while at the same time blocking those threads in invokeAndWait. Moving the window during startup could therefore deadlock the event dispatch thread, in replay mode the client hung completely.

- create the user interface on the event dispatch thread and connect to the server on a dedicated startup thread
- add UiDispatcher and route dialogs, chat/log document changes, replay control and UserInterface.init through the event dispatch thread
- no longer hold monitors while handing work over to the event dispatch thread (icon progress, icon load failures, replay status command)
- coalesce progress bar updates and stop relayouting the dialog for every step, fill the detached replay log without event dispatch thread round trips
- guard the animation wait with a flag and a timeout so a missed notification cannot block command processing
- replace the about dialog's java.util.Timer with a swing timer